### PR TITLE
[core] move content.Item to unix-y Timestamp and Updated fields

### DIFF
--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -36,11 +36,11 @@ new <directory>:
 
 generate, gen, g <type>:
 
-    Generate a content type file with boilerplate code to implement
-    the editor.Editable interface. Must be given one (1) parameter of
-    the name of the type for the new content.
+	Generate a content type file with boilerplate code to implement
+	the editor.Editable interface. Must be given one (1) parameter of
+	the name of the type for the new content.
 
-    Example:
+	Example:
 	$ ponzu gen review
 
 
@@ -67,6 +67,7 @@ generate, gen, g <type>:
 	database, since the first process to open it recieves a lock. If you intend
 	to run the Admin and API on separate processes, you must call them with the
 	'ponzu' command independently.
+
 `
 
 var (

--- a/content/item.go
+++ b/content/item.go
@@ -1,11 +1,9 @@
 package content
 
-import "time"
-
 // Item should only be embedded into content type structs.
 type Item struct {
-	ID        int       `json:"id"`
-	Slug      string    `json:"slug"`
-	Timestamp time.Time `json:"timestamp"`
-	Updated   time.Time `json:"updated"`
+	ID        int    `json:"id"`
+	Slug      string `json:"slug"`
+	Timestamp int64  `json:"timestamp"`
+	Updated   int64  `json:"updated"`
 }

--- a/content/item.go
+++ b/content/item.go
@@ -6,8 +6,6 @@ import "time"
 type Item struct {
 	ID        int       `json:"id"`
 	Slug      string    `json:"slug"`
-	Time      string    `json:"time"`
-	Date      string    `json:"date"`
 	Timestamp time.Time `json:"timestamp"`
 	Updated   time.Time `json:"updated"`
 }

--- a/content/item.go
+++ b/content/item.go
@@ -1,8 +1,13 @@
 package content
 
+import "time"
+
 // Item should only be embedded into content type structs.
 type Item struct {
-	ID        int    `json:"id"`
-	Slug      string `json:"slug"`
-	Timestamp string `json:"timestamp"`
+	ID        int       `json:"id"`
+	Slug      string    `json:"slug"`
+	Time      string    `json:"time"`
+	Date      string    `json:"date"`
+	Timestamp time.Time `json:"timestamp"`
+	Updated   time.Time `json:"updated"`
 }

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -65,24 +65,25 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	</div>
 	<div class="input-field col s2">
 		<label class="active">DD</label>
-		<input value="" class="day __ponzu" type="text" placeholder="DD" />
+		<input value="" class="day __ponzu" maxlength="2" type="text" placeholder="DD" />
 	</div>
 	<div class="input-field col s4">
 		<label class="active">YYYY</label>
-		<input value="" class="year __ponzu" type="text" placeholder="YYYY" />
+		<input value="" class="year __ponzu" maxlength="4" type="text" placeholder="YYYY" />
 	</div>
 </div>
 
 <div class="row">
 	<div class="input-field col s3">
 		<label class="active">HH</label>
-		<input value="" class="hour __ponzu" type="text" placeholder="HH" />
+		<input value="" class="hour __ponzu" maxlength="2" type="text" placeholder="HH" />
 	</div>
+	<div class="col s1">:</div>
 	<div class="input-field col s3">
 		<label class="active">MM</label>
-		<input value="" class="minute __ponzu" type="text" placeholder="MM" />
+		<input value="" class="minute __ponzu" maxlength="2" type="text" placeholder="MM" />
 	</div>
-	<div class="input-field col s3">
+	<div class="input-field col s4">
 		<label class="active">Period</label>
 		<select class="period __ponzu browser-default">
 			<option value="AM">AM</option>

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -146,6 +146,18 @@ func addPostDefaultFieldsToEditorView(p Editable, e *Editor) {
 				"placeholder": "Will be set automatically",
 			}),
 		},
+		Field{
+			View: Input("Timestamp", p, map[string]string{
+				"type":  "hidden",
+				"class": "timestamp __ponzu",
+			}),
+		},
+		Field{
+			View: Input("Updated", p, map[string]string{
+				"type":  "hidden",
+				"class": "updated __ponzu",
+			}),
+		},
 	}
 
 	for _, f := range defaults {

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -45,13 +45,39 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	editor.ViewBuf.Write([]byte(`<tr class="col s4 default-fields"><td>`))
 
 	publishTime := `
-<div class="input-field col s12">
-	<label class="active" for="Publish-Date">Publish Date</label>
-	<input value="" class="date __ponzu" label="Publish Date" type="date" name="date" />
+<div class="input-field col s3">
+	<label class="active">MM</label>
+	<select class="month __ponzu">
+		<option value="0">Jan - 01</option>
+		<option value="1">Feb - 02</option>
+		<option value="2">Mar - 03</option>
+		<option value="3">Apr - 04</option>
+		<option value="4">May - 05</option>
+		<option value="5">Jun - 06</option>
+		<option value="6">Jul - 07</option>
+		<option value="7">Aug - 08</option>
+		<option value="8">Sep - 09</option>
+		<option value="9">Oct - 10</option>
+		<option value="10">Nov - 11</option>
+		<option value="11">Dec - 12</option>
+	</select>
 </div>
-<div class="input-field col s12">
-	<label class="active" for="Publish-Time">Publish Time</label>
-	<input value="" class="time __ponzu" label="Publish Time" type="time" name="time" />
+<div class="input-field col s2">
+	<label class="active">DD</label>
+	<input value="" class="day __ponzu" type="text" placeholder="DD" />
+</div>
+<div class="input-field col s2">
+	<label class="active">YYYY</label>
+	<input value="" class="year __ponzu" type="text" placeholder="YYYY" />
+</div>
+<div class col s1>@</div>
+<div class="input-field col s2">
+	<label class="active">HH</label>
+	<input value="" class="hour __ponzu" type="text" placeholder="HH" />
+</div>
+<div class="input-field col s2">
+	<label class="active">MM</label>
+	<input value="" class="minute __ponzu" type="text" placeholder="MM" />
 </div>
 	`
 

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -48,7 +48,7 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 <div class="row">
 	<div class="input-field col s6">
 		<label class="active">MM</label>
-		<select class="month __ponzu">
+		<select class="month __ponzu browser-default">
 			<option value="0">Jan - 01</option>
 			<option value="1">Feb - 02</option>
 			<option value="2">Mar - 03</option>

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -87,9 +87,17 @@ func addFieldToEditorView(e *Editor, f Field) {
 func addPostDefaultFieldsToEditorView(p Editable, e *Editor) {
 	defaults := []Field{
 		Field{
-			View: Input("Timestamp", p, map[string]string{
+			View: Input("Date", p, map[string]string{
 				"label": "Publish Date",
 				"type":  "date",
+				"class": "date __ponzu",
+			}),
+		},
+		Field{
+			View: Input("Time", p, map[string]string{
+				"label": "Publish Time",
+				"type":  "time",
+				"class": "time __ponzu",
 			}),
 		},
 		Field{

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -82,6 +82,13 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 		<label class="active">MM</label>
 		<input value="" class="minute __ponzu" type="text" placeholder="MM" />
 	</div>
+	<div class="input-field col s3">
+		<label class="active">Period</label>
+		<select class="period __ponzu browser-default">
+			<option value="AM">AM</option>
+			<option value="PM">PM</option>
+		</select>
+	</div>
 </div>
 	`
 

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -43,6 +43,20 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 
 	// content items with Item embedded have some default fields we need to render
 	editor.ViewBuf.Write([]byte(`<tr class="col s4 default-fields"><td>`))
+
+	publishTime := `
+<div class="input-field col s12">
+	<label class="active" for="Publish-Date">Publish Date</label>
+	<input value="" class="date __ponzu" label="Publish Date" type="date" name="date" />
+</div>
+<div class="input-field col s12">
+	<label class="active" for="Publish-Time">Publish Time</label>
+	<input value="" class="time __ponzu" label="Publish Time" type="time" name="time" />
+</div>
+	`
+
+	editor.ViewBuf.Write([]byte(publishTime))
+
 	addPostDefaultFieldsToEditorView(post, editor)
 
 	submit := `
@@ -86,20 +100,6 @@ func addFieldToEditorView(e *Editor, f Field) {
 
 func addPostDefaultFieldsToEditorView(p Editable, e *Editor) {
 	defaults := []Field{
-		Field{
-			View: Input("Date", p, map[string]string{
-				"label": "Publish Date",
-				"type":  "date",
-				"class": "date __ponzu",
-			}),
-		},
-		Field{
-			View: Input("Time", p, map[string]string{
-				"label": "Publish Time",
-				"type":  "time",
-				"class": "time __ponzu",
-			}),
-		},
 		Field{
 			View: Input("Slug", p, map[string]string{
 				"label":       "URL Slug",

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -147,13 +147,13 @@ func addPostDefaultFieldsToEditorView(p Editable, e *Editor) {
 			}),
 		},
 		Field{
-			View: Input("Timestamp", p, map[string]string{
+			View: Timestamp("Timestamp", p, map[string]string{
 				"type":  "hidden",
 				"class": "timestamp __ponzu",
 			}),
 		},
 		Field{
-			View: Input("Updated", p, map[string]string{
+			View: Timestamp("Updated", p, map[string]string{
 				"type":  "hidden",
 				"class": "updated __ponzu",
 			}),

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -49,18 +49,18 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<div class="input-field col s6">
 		<label class="active">MM</label>
 		<select class="month __ponzu browser-default">
-			<option value="0">Jan - 01</option>
-			<option value="1">Feb - 02</option>
-			<option value="2">Mar - 03</option>
-			<option value="3">Apr - 04</option>
-			<option value="4">May - 05</option>
-			<option value="5">Jun - 06</option>
-			<option value="6">Jul - 07</option>
-			<option value="7">Aug - 08</option>
-			<option value="8">Sep - 09</option>
-			<option value="9">Oct - 10</option>
-			<option value="10">Nov - 11</option>
-			<option value="11">Dec - 12</option>
+			<option value="1">Jan - 01</option>
+			<option value="2">Feb - 02</option>
+			<option value="3">Mar - 03</option>
+			<option value="4">Apr - 04</option>
+			<option value="5">May - 05</option>
+			<option value="6">Jun - 06</option>
+			<option value="7">Jul - 07</option>
+			<option value="8">Aug - 08</option>
+			<option value="9">Sep - 09</option>
+			<option value="10">Oct - 10</option>
+			<option value="11">Nov - 11</option>
+			<option value="12">Dec - 12</option>
 		</select>
 	</div>
 	<div class="input-field col s2">

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -45,39 +45,43 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	editor.ViewBuf.Write([]byte(`<tr class="col s4 default-fields"><td>`))
 
 	publishTime := `
-<div class="input-field col s3">
-	<label class="active">MM</label>
-	<select class="month __ponzu">
-		<option value="0">Jan - 01</option>
-		<option value="1">Feb - 02</option>
-		<option value="2">Mar - 03</option>
-		<option value="3">Apr - 04</option>
-		<option value="4">May - 05</option>
-		<option value="5">Jun - 06</option>
-		<option value="6">Jul - 07</option>
-		<option value="7">Aug - 08</option>
-		<option value="8">Sep - 09</option>
-		<option value="9">Oct - 10</option>
-		<option value="10">Nov - 11</option>
-		<option value="11">Dec - 12</option>
-	</select>
+<div class="row">
+	<div class="input-field col s6">
+		<label class="active">MM</label>
+		<select class="month __ponzu">
+			<option value="0">Jan - 01</option>
+			<option value="1">Feb - 02</option>
+			<option value="2">Mar - 03</option>
+			<option value="3">Apr - 04</option>
+			<option value="4">May - 05</option>
+			<option value="5">Jun - 06</option>
+			<option value="6">Jul - 07</option>
+			<option value="7">Aug - 08</option>
+			<option value="8">Sep - 09</option>
+			<option value="9">Oct - 10</option>
+			<option value="10">Nov - 11</option>
+			<option value="11">Dec - 12</option>
+		</select>
+	</div>
+	<div class="input-field col s2">
+		<label class="active">DD</label>
+		<input value="" class="day __ponzu" type="text" placeholder="DD" />
+	</div>
+	<div class="input-field col s4">
+		<label class="active">YYYY</label>
+		<input value="" class="year __ponzu" type="text" placeholder="YYYY" />
+	</div>
 </div>
-<div class="input-field col s2">
-	<label class="active">DD</label>
-	<input value="" class="day __ponzu" type="text" placeholder="DD" />
-</div>
-<div class="input-field col s2">
-	<label class="active">YYYY</label>
-	<input value="" class="year __ponzu" type="text" placeholder="YYYY" />
-</div>
-<div class col s1>@</div>
-<div class="input-field col s2">
-	<label class="active">HH</label>
-	<input value="" class="hour __ponzu" type="text" placeholder="HH" />
-</div>
-<div class="input-field col s2">
-	<label class="active">MM</label>
-	<input value="" class="minute __ponzu" type="text" placeholder="MM" />
+
+<div class="row">
+	<div class="input-field col s3">
+		<label class="active">HH</label>
+		<input value="" class="hour __ponzu" type="text" placeholder="HH" />
+	</div>
+	<div class="input-field col s3">
+		<label class="active">MM</label>
+		<input value="" class="minute __ponzu" type="text" placeholder="MM" />
+	</div>
 </div>
 	`
 

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -37,11 +37,11 @@ func Textarea(fieldName string, p interface{}, attrs map[string]string) []byte {
 	return domElement(e)
 }
 
-// Time returns the []byte of an <input> HTML element with a label.
+// Timestamp returns the []byte of an <input> HTML element with a label.
 // IMPORTANT:
 // The `fieldName` argument will cause a panic if it is not exactly the string
 // form of the struct field that this editor input is representing
-func Time(fieldName string, p interface{}, attrs map[string]string) []byte {
+func Timestamp(fieldName string, p interface{}, attrs map[string]string) []byte {
 	var data string
 	val := valueFromStructField(fieldName, p)
 	if val.Int() == 0 {

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -47,7 +47,7 @@ func Timestamp(fieldName string, p interface{}, attrs map[string]string) []byte 
 	if val.Int() == 0 {
 		data = ""
 	} else {
-		data = val.String()
+		data = fmt.Sprintf("%d", val.Int())
 	}
 
 	e := &element{

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -451,7 +451,7 @@ func tagNameFromStructFieldMulti(name string, i int, post interface{}) string {
 func valueFromStructField(name string, post interface{}) reflect.Value {
 	field := reflect.Indirect(reflect.ValueOf(post)).FieldByName(name)
 
-	fmt.Println(name, field)
+	fmt.Println(name, field, field.String())
 
 	return field
 }

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -37,6 +37,31 @@ func Textarea(fieldName string, p interface{}, attrs map[string]string) []byte {
 	return domElement(e)
 }
 
+// Time returns the []byte of an <input> HTML element with a label.
+// IMPORTANT:
+// The `fieldName` argument will cause a panic if it is not exactly the string
+// form of the struct field that this editor input is representing
+func Time(fieldName string, p interface{}, attrs map[string]string) []byte {
+	var data string
+	val := valueFromStructField(fieldName, p)
+	if val.Int() == 0 {
+		data = ""
+	} else {
+		data = val.String()
+	}
+
+	e := &element{
+		TagName: "input",
+		Attrs:   attrs,
+		Name:    tagNameFromStructField(fieldName, p),
+		label:   attrs["label"],
+		data:    data,
+		viewBuf: &bytes.Buffer{},
+	}
+
+	return domElementSelfClose(e)
+}
+
 // File returns the []byte of a <input type="file"> HTML element with a label.
 // IMPORTANT:
 // The `fieldName` argument will cause a panic if it is not exactly the string
@@ -450,8 +475,6 @@ func tagNameFromStructFieldMulti(name string, i int, post interface{}) string {
 
 func valueFromStructField(name string, post interface{}) reflect.Value {
 	field := reflect.Indirect(reflect.ValueOf(post)).FieldByName(name)
-
-	fmt.Println(name, field, field.String())
 
 	return field
 }

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -451,6 +451,8 @@ func tagNameFromStructFieldMulti(name string, i int, post interface{}) string {
 func valueFromStructField(name string, post interface{}) reflect.Value {
 	field := reflect.Indirect(reflect.ValueOf(post)).FieldByName(name)
 
+	fmt.Println(name, field)
+
 	return field
 }
 

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -25,13 +25,32 @@ const managerHTML = `
 				e.target.value = replaceBadChars(val);
 			});
 
+			var setDefaultTimeAndDate = function($pt, $pd, $ts, $up, unix) {
+				var time = getPartialTime(now),
+					date = getPartialDate(now);
+
+				$pt.val(time);
+				$pd.val(date);
+				$ts.val(unix);
+				$up.val(unix);
+			}
+
 			// set time time and date inputs using the hidden timestamp input.
 			// if it is empty, set it to now and use that value for time and date
 			var publish_time = $('input.__ponzu.time'),
 				publish_date = $('input.__ponzu.date'),
-				now = new Date();
+				timestamp = $('input.__ponzu.timestamp'),
+				updated = $('input.__ponzu.updated'),
+				time;
 
-			// set updated value to now
+			if (timestamp.val() !== "") {
+				time = timestamp.val();
+			} else {
+				time = (new Date()).getTime();
+			}
+
+			setDefaultTimeAndDate(publish_time, publish_date, timestamp, updated, time);
+			
 		});
 	</script>
 </div>

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -30,7 +30,7 @@ const managerHTML = `
 					month = dt.month.val()-1,
 					day = dt.day.val(),
 					hour = dt.hour.val(),
-					minutes = dt.minute.val();
+					minute = dt.minute.val();
 
 					if (dt.period == "PM") {
 						hours = hours + 12;

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -13,15 +13,25 @@ const managerHTML = `
     <form method="post" action="/admin/edit" enctype="multipart/form-data">
 		<input type="hidden" name="id" value="{{.ID}}"/>
 		<input type="hidden" name="type" value="{{.Kind}}"/>
-		<input type="hidden" name="timestamp" value="" />
-		<input type="hidden" name="updated" value="" />
+		<input type="hidden" name="timestamp" class="timestamp __ponzu" value="" />
+		<input type="hidden" name="updated" class="updated __ponzu" value="" />
 		{{ .Editor }}
 	</form>
 	<script>
-		// remove all bad chars from all inputs in the form, except file fields
-		$('form input:not([type=file]), form textarea').on('blur', function(e) {
-			var val = e.target.value;
-			e.target.value = replaceBadChars(val);
+		$(function() {
+			// remove all bad chars from all inputs in the form, except file fields
+			$('form input:not([type=file]), form textarea').on('blur', function(e) {
+				var val = e.target.value;
+				e.target.value = replaceBadChars(val);
+			});
+
+			// set time time and date inputs using the hidden timestamp input.
+			// if it is empty, set it to now and use that value for time and date
+			var publish_time = $('input.__ponzu.time'),
+				publish_date = $('input.__ponzu.date'),
+				now = new Date();
+
+			// set updated value to now
 		});
 	</script>
 </div>

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -25,6 +25,22 @@ const managerHTML = `
 				e.target.value = replaceBadChars(val);
 			});
 
+			var updateTimestamp = function(dt, $ts) {
+				var year = dt.year.val(),
+					month = dt.month.val()-1,
+					day = dt.day.val(),
+					hours = dt.hours.val(),
+					minutes = dt.minutes.val();
+
+					if (dt.period == "PM") {
+						hours = hours + 12;
+					}
+
+				var date = new Date(year, month, day, hours, minutes);
+				
+				$ts.val(date.getTime());
+			}
+
 			var setDefaultTimeAndDate = function(dt, $ts, $up, unix) {
 				var time = getPartialTime(unix),
 					date = getPartialDate(unix);
@@ -36,10 +52,7 @@ const managerHTML = `
 				dt.month.val(date.mm);
 				dt.day.val(date.dd);
 				
-				if ($ts.val() === "") {
-					$ts.val(unix);					
-				}
-
+				$ts.val(unix);					
 				$up.val(unix);
 			}
 
@@ -82,8 +95,7 @@ const managerHTML = `
 
 				e.preventDefault();
 
-				var time = (new Date()).getTime();
-				setDefaultTimeAndDate(getFields(), timestamp, updated, time);
+				updateTimestamp(getFields(), timestamp);
 
 				timeUpdated = true;
 				$('form').submit();				

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -13,8 +13,6 @@ const managerHTML = `
     <form method="post" action="/admin/edit" enctype="multipart/form-data">
 		<input type="hidden" name="id" value="{{.ID}}"/>
 		<input type="hidden" name="type" value="{{.Kind}}"/>
-		<input type="hidden" name="timestamp" class="timestamp __ponzu" value="" />
-		<input type="hidden" name="updated" class="updated __ponzu" value="" />
 		{{ .Editor }}
 	</form>
 	<script>
@@ -50,10 +48,7 @@ const managerHTML = `
 				dt.period.val(time.pd);
 				dt.year.val(date.yyyy);
 				dt.month.val(date.mm);
-				dt.day.val(date.dd);
-				
-				$ts.val(unix);					
-				$up.val(unix);
+				dt.day.val(date.dd);				
 			}
 
 			// set time time and date inputs using the hidden timestamp input.

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -29,14 +29,14 @@ const managerHTML = `
 				var year = dt.year.val(),
 					month = dt.month.val()-1,
 					day = dt.day.val(),
-					hours = dt.hours.val(),
-					minutes = dt.minutes.val();
+					hour = dt.hour.val(),
+					minutes = dt.minute.val();
 
 					if (dt.period == "PM") {
 						hours = hours + 12;
 					}
 
-				var date = new Date(year, month, day, hours, minutes);
+				var date = new Date(year, month, day, hour, minute);
 				
 				$ts.val(date.getTime());
 			}

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -25,22 +25,37 @@ const managerHTML = `
 				e.target.value = replaceBadChars(val);
 			});
 
-			var setDefaultTimeAndDate = function($pt, $pd, $ts, $up, unix) {
+			var setDefaultTimeAndDate = function(dt, $ts, $up, unix) {
 				var time = getPartialTime(unix),
 					date = getPartialDate(unix);
 
-				$pt.val(time);
-				$pd.val(date);
+				dt.hour.val(time.hh);
+				dt.minute.val(time.mm);
+				dt.year.val(date.yyyy);
+				dt.month.val(date.mm);
+				dt.day.val(date.dd);
 				$ts.val(unix);
 				$up.val(unix);
 			}
 
 			// set time time and date inputs using the hidden timestamp input.
 			// if it is empty, set it to now and use that value for time and date
-			var publish_time = $('input.__ponzu.time'),
-				publish_date = $('input.__ponzu.date'),
+			var publish_time_hh = $('input.__ponzu.hour'),
+				publish_time_mm = $('input.__ponzu.minute'),
+				publish_date_yyyy = $('input.__ponzu.year'),
+				publish_date_mm = $('input.__ponzu.month'),
+				publish_date_dd = $('input.__ponzu.day'),
 				timestamp = $('input.__ponzu.timestamp'),
 				updated = $('input.__ponzu.updated'),
+				getFields = function() {
+					return {
+						hour: publish_time_hh,
+						minute: publish_time_mm,
+						year: publish_time_yyyy,
+						month: publish_time_mm,
+						day: publish_time_dd
+					}
+				},
 				time;
 
 			if (timestamp.val() !== "") {
@@ -49,7 +64,7 @@ const managerHTML = `
 				time = (new Date()).getTime();
 			}
 
-			setDefaultTimeAndDate(publish_time, publish_date, timestamp, updated, time);
+			setDefaultTimeAndDate(getFields(), timestamp, updated, time);
 			
 		});
 	</script>

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -13,6 +13,8 @@ const managerHTML = `
     <form method="post" action="/admin/edit" enctype="multipart/form-data">
 		<input type="hidden" name="id" value="{{.ID}}"/>
 		<input type="hidden" name="type" value="{{.Kind}}"/>
+		<input type="hidden" name="timestamp" value="" />
+		<input type="hidden" name="updated" value="" />
 		{{ .Editor }}
 	</form>
 	<script>

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -51,9 +51,9 @@ const managerHTML = `
 					return {
 						hour: publish_time_hh,
 						minute: publish_time_mm,
-						year: publish_time_yyyy,
-						month: publish_time_mm,
-						day: publish_time_dd
+						year: publish_date_yyyy,
+						month: publish_date_mm,
+						day: publish_date_dd
 					}
 				},
 				time;

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -74,7 +74,7 @@ const managerHTML = `
 				time;
 
 			if (timestamp.val() !== "") {
-				time = timestamp.val();
+				time = parseInt(timestamp.val());
 			} else {
 				time = (new Date()).getTime();
 			}

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -35,7 +35,11 @@ const managerHTML = `
 				dt.year.val(date.yyyy);
 				dt.month.val(date.mm);
 				dt.day.val(date.dd);
-				$ts.val(unix);
+				
+				if ($ts.val() === "") {
+					$ts.val(unix);					
+				}
+
 				$up.val(unix);
 			}
 
@@ -69,7 +73,23 @@ const managerHTML = `
 
 			setDefaultTimeAndDate(getFields(), timestamp, updated, time);
 			
+			var timeUpdated = false;
+			$('form').on('submit', function(e) {
+				if (timeUpdated === true) {
+					timeUpdated = false;
+					return;
+				}
+
+				e.preventDefault();
+
+				var time = (new Date()).getTime();
+				setDefaultTimeAndDate(getFields(), timestamp, updated, time);
+
+				timeUpdated = true;
+				$('form').submit();				
+			});
 		});
+		
 	</script>
 </div>
 `

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -26,8 +26,8 @@ const managerHTML = `
 			});
 
 			var setDefaultTimeAndDate = function($pt, $pd, $ts, $up, unix) {
-				var time = getPartialTime(now),
-					date = getPartialDate(now);
+				var time = getPartialTime(unix),
+					date = getPartialDate(unix);
 
 				$pt.val(time);
 				$pd.val(date);

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -31,6 +31,7 @@ const managerHTML = `
 
 				dt.hour.val(time.hh);
 				dt.minute.val(time.mm);
+				dt.period.val(time.pd);
 				dt.year.val(date.yyyy);
 				dt.month.val(date.mm);
 				dt.day.val(date.dd);
@@ -42,8 +43,9 @@ const managerHTML = `
 			// if it is empty, set it to now and use that value for time and date
 			var publish_time_hh = $('input.__ponzu.hour'),
 				publish_time_mm = $('input.__ponzu.minute'),
+				publish_time_pd = $('select.__ponzu.period'),				
 				publish_date_yyyy = $('input.__ponzu.year'),
-				publish_date_mm = $('input.__ponzu.month'),
+				publish_date_mm = $('select.__ponzu.month'),
 				publish_date_dd = $('input.__ponzu.day'),
 				timestamp = $('input.__ponzu.timestamp'),
 				updated = $('input.__ponzu.updated'),
@@ -51,6 +53,7 @@ const managerHTML = `
 					return {
 						hour: publish_time_hh,
 						minute: publish_time_mm,
+						period: publish_time_pd,
 						year: publish_date_yyyy,
 						month: publish_date_mm,
 						day: publish_date_dd

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -435,19 +435,16 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 		cid := req.FormValue("id")
 		t := req.FormValue("type")
 		ts := req.FormValue("timestamp")
+		up := req.FormValue("updated")
 
 		// create a timestamp if one was not set
-		date := make(map[string]int)
 		if ts == "" {
-			now := time.Now()
-			date["year"] = now.Year()
-			date["month"] = int(now.Month())
-			date["day"] = now.Day()
-
-			// create timestamp format 'yyyy-mm-dd' and set in PostForm for
-			// db insertion
-			ts = fmt.Sprintf("%d-%02d-%02d", date["year"], date["month"], date["day"])
+			ts := fmt.Sprintf("%d", time.Now().Unix()*1000)
 			req.PostForm.Set("timestamp", ts)
+		}
+
+		if up == "" {
+			req.PostForm.Set("updated", ts)
 		}
 
 		urlPaths, err := storeFileUploads(req)

--- a/system/admin/static/common/js/util.js
+++ b/system/admin/static/common/js/util.js
@@ -23,34 +23,42 @@ function replaceBadChars(text) {
 }
 
 
-// Returns a local partial time based on unix timestamp (i.e. HH:MM:SS)
+// Returns a local partial time object based on unix timestamp
 function getPartialTime(unix) {
     var date = new Date(unix);
-    var parts = [];
-    parts.push(date.getHours());
-    parts.push(date.getMinutes());
-    parts.push(date.getSeconds());
+    var t = {};
+    var hours = date.getHours();
+    if (hours < 10) {
+        hours = "0" + String(hours);
+    }
+    t.hh = hours;
 
-    return parts.join(":");
+    var minutes = date.getMinutes();
+    if (minutes < 10) {
+        minutes = "0" + String(minutes);
+    }
+    t.mm = minutes;
+
+    return t;
 }
 
-// Returns a local partial date based on unix timestamp (YYYY-MM-DD)
+// Returns a local partial date object based on unix timestamp
 function getPartialDate(unix) {
     var date = new Date(unix);
-    var parts = [];
-    parts.push(date.getFullYear());
+    var d = {};
+    d.yyyy = date.getFullYear();
     
     var month = date.getMonth()+1;
     if (month < 10) {
         month = "0" + String(month);
     }
-    parts.push(month);
+    d.mm = month;
 
     var day = date.getDate();
     if (day < 10) {
         day = "0" + String(day);
     }
-    parts.push(day);
+    d.dd = day;
 
-    return parts.join("-");
+    return d;
 }

--- a/system/admin/static/common/js/util.js
+++ b/system/admin/static/common/js/util.js
@@ -46,13 +46,10 @@ function getPartialTime(unix) {
 function getPartialDate(unix) {
     var date = new Date(unix);
     var d = {};
+    
     d.yyyy = date.getFullYear();
     
-    var month = date.getMonth()+1;
-    if (month < 10) {
-        month = "0" + String(month);
-    }
-    d.mm = month;
+    d.mm = date.getMonth()+1;
 
     var day = date.getDate();
     if (day < 10) {

--- a/system/admin/static/common/js/util.js
+++ b/system/admin/static/common/js/util.js
@@ -21,3 +21,14 @@ function replaceBadChars(text) {
     
     return s;
 }
+
+
+// Returns a local partial time based on unix timestamp
+function getPartialTime(date) {
+    var parts = [];
+    parts.push(date.getHours())
+    parts.push(date.getMinutes())
+    parts.push(date.getSeconds())
+
+    return parts.join(":");
+}

--- a/system/admin/static/common/js/util.js
+++ b/system/admin/static/common/js/util.js
@@ -31,7 +31,16 @@ function getPartialTime(unix) {
     if (hours < 10) {
         hours = "0" + String(hours);
     }
+
     t.hh = hours;
+    if (hours > 12) {
+        t.hh = hours - 12;
+        t.pd = "PM";
+    } else if (hours === 12) {
+        t.pd = "PM";
+    } else if (hours < 12) {
+        t.pd = "AM";
+    }
 
     var minutes = date.getMinutes();
     if (minutes < 10) {

--- a/system/admin/static/common/js/util.js
+++ b/system/admin/static/common/js/util.js
@@ -23,12 +23,34 @@ function replaceBadChars(text) {
 }
 
 
-// Returns a local partial time based on unix timestamp
-function getPartialTime(date) {
+// Returns a local partial time based on unix timestamp (i.e. HH:MM:SS)
+function getPartialTime(unix) {
+    var date = new Date(unix);
     var parts = [];
-    parts.push(date.getHours())
-    parts.push(date.getMinutes())
-    parts.push(date.getSeconds())
+    parts.push(date.getHours());
+    parts.push(date.getMinutes());
+    parts.push(date.getSeconds());
 
     return parts.join(":");
+}
+
+// Returns a local partial date based on unix timestamp (YYYY-MM-DD)
+function getPartialDate(unix) {
+    var date = new Date(unix);
+    var parts = [];
+    parts.push(date.getFullYear());
+    
+    var month = date.getMonth()+1;
+    if (month < 10) {
+        month = "0" + String(month);
+    }
+    parts.push(month);
+
+    var day = date.getDate();
+    if (day < 10) {
+        day = "0" + String(day);
+    }
+    parts.push(day);
+
+    return parts.join("-");
 }

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -32,6 +32,8 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	// num := q.Get("num")
 	// page := q.Get("page")
 
+	// TODO: inplement time-based ?after=time.Time, ?before=time.Time between=time.Time|time.Time
+
 	if t == "" {
 		res.WriteHeader(http.StatusBadRequest)
 		return


### PR DESCRIPTION
Added the necessary changes across the codebase to support more rich time recording, which will also help add sorting later on. 

```go
type Item struct {
	ID        int    `json:"id"`
	Slug      string `json:"slug"`
	Timestamp int64  `json:"timestamp"`
	Updated   int64  `json:"updated"`
}
```

Also, added a useful Timestamp function to use as an editor input element. Note for future additional input elements how the data field is set based on the return reflect value from `valueFromStructField()`: 

```go
func Timestamp(fieldName string, p interface{}, attrs map[string]string) []byte {
	var data string
	val := valueFromStructField(fieldName, p)
	if val.Int() == 0 {
		data = ""
	} else {
		data = fmt.Sprintf("%d", val.Int())
	}

	e := &element{
		TagName: "input",
		Attrs:   attrs,
		Name:    tagNameFromStructField(fieldName, p),
		label:   attrs["label"],
		data:    data,
		viewBuf: &bytes.Buffer{},
	}

	return domElementSelfClose(e)
}
```