### PR TITLE
[fundamental feature] Content type posts are sorted by time and cached in Admin, API coming soon.

### DIFF
--- a/content/item.go
+++ b/content/item.go
@@ -7,3 +7,8 @@ type Item struct {
 	Timestamp int64  `json:"timestamp"`
 	Updated   int64  `json:"updated"`
 }
+
+// Time implements the Sortable interface
+func (i Item) Time() int64 {
+	return i.Timestamp
+}

--- a/content/item.go
+++ b/content/item.go
@@ -8,7 +8,12 @@ type Item struct {
 	Updated   int64  `json:"updated"`
 }
 
-// Time implements the Sortable interface
+// Time partially implements the Sortable interface
 func (i Item) Time() int64 {
 	return i.Timestamp
+}
+
+// ContentID partially implements the Sortable interface
+func (i Item) ContentID() int {
+	return i.ID
 }

--- a/content/item.go
+++ b/content/item.go
@@ -13,6 +13,11 @@ func (i Item) Time() int64 {
 	return i.Timestamp
 }
 
+// Touch partially implements the Sortable interface
+func (i Item) Touch() int64 {
+	return i.Updated
+}
+
 // ContentID partially implements the Sortable interface
 func (i Item) ContentID() int {
 	return i.ID

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -16,6 +16,11 @@ type Editable interface {
 	MarshalEditor() ([]byte, error)
 }
 
+// Sortable ensures data is sortable by time
+type Sortable interface {
+	Time() int64
+}
+
 // Editor is a view containing fields to manage content
 type Editor struct {
 	ViewBuf *bytes.Buffer

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -19,6 +19,7 @@ type Editable interface {
 // Sortable ensures data is sortable by time
 type Sortable interface {
 	Time() int64
+	ContentID() int
 }
 
 // Editor is a view containing fields to manage content

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -19,6 +19,7 @@ type Editable interface {
 // Sortable ensures data is sortable by time
 type Sortable interface {
 	Time() int64
+	Touch() int64
 	ContentID() int
 }
 

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -52,7 +52,7 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	editor.ViewBuf.Write([]byte(`<tr class="col s4 default-fields"><td>`))
 
 	publishTime := `
-<div class="row">
+<div class="row content-only __ponzu">
 	<div class="input-field col s6">
 		<label class="active">MM</label>
 		<select class="month __ponzu browser-default">
@@ -80,7 +80,7 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	</div>
 </div>
 
-<div class="row">
+<div class="row content-only __ponzu">
 	<div class="input-field col s3">
 		<label class="active">HH</label>
 		<input value="" class="hour __ponzu" maxlength="2" type="text" placeholder="HH" />

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -128,7 +128,6 @@ func File(fieldName string, p interface{}, attrs map[string]string) []byte {
 					store.attr('name', '');
 					upload.attr('name', '` + name + `');
 					clip.empty();
-					console.log('clicked');
 				}
 			});	
 		</script>`
@@ -198,10 +197,8 @@ func Richtext(fieldName string, p interface{}, attrs map[string]string) []byte {
 						contentType: false,
 						processData: false,
 						success: function(resp) {
-							console.log(resp);
 							var img = document.createElement('img');
 							img.setAttribute('src', resp.data[0].url);
-							console.log(img);
 							_editor.materialnote('insertNode', img);
 						},
 						error: function(xhr, status, err) {

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -31,7 +31,7 @@ const managerHTML = `
 					minute = dt.minute.val();
 
 					if (dt.period == "PM") {
-						hours = hours + 12;
+						hour = hour + 12;
 					}
 
 				var date = new Date(year, month, day, hour, minute);

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -39,7 +39,7 @@ const managerHTML = `
 				$ts.val(date.getTime());
 			}
 
-			var setDefaultTimeAndDate = function(dt, $ts, $up, unix) {
+			var setDefaultTimeAndDate = function(dt, unix) {
 				var time = getPartialTime(unix),
 					date = getPartialDate(unix);
 
@@ -79,7 +79,7 @@ const managerHTML = `
 				time = (new Date()).getTime();
 			}
 
-			setDefaultTimeAndDate(getFields(), timestamp, updated, time);
+			setDefaultTimeAndDate(getFields(), time);
 			
 			var timeUpdated = false;
 			$('form').on('submit', function(e) {
@@ -91,6 +91,7 @@ const managerHTML = `
 				e.preventDefault();
 
 				updateTimestamp(getFields(), timestamp);
+				updated.val((new Date()).getTime());
 
 				timeUpdated = true;
 				$('form').submit();				

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -24,13 +24,13 @@ const managerHTML = `
 			});
 
 			var updateTimestamp = function(dt, $ts) {
-				var year = dt.year.val(),
-					month = dt.month.val()-1,
-					day = dt.day.val(),
-					hour = dt.hour.val(),
-					minute = dt.minute.val();
+				var year = parseInt(dt.year.val()),
+					month = parseInt(dt.month.val())-1,
+					day = parseInt(dt.day.val()),
+					hour = parseInt(dt.hour.val()),
+					minute = parseInt(dt.minute.val());
 
-					if (dt.period == "PM") {
+					if (dt.period === "PM") {
 						hour = hour + 12;
 					}
 

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -24,14 +24,15 @@ const managerHTML = `
 			});
 
 			var updateTimestamp = function(dt, $ts) {
-				console.log(dt);
 				var year = parseInt(dt.year.val()),
 					month = parseInt(dt.month.val())-1,
 					day = parseInt(dt.day.val()),
 					hour = parseInt(dt.hour.val()),
 					minute = parseInt(dt.minute.val());
 
-					if (dt.period === "PM") {
+					console.log(year, month, day, hour, minute);
+
+					if (dt.period.val() === "PM") {
 						hour = hour + 12;
 						console.log(hour);
 					}

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -24,6 +24,7 @@ const managerHTML = `
 			});
 
 			var updateTimestamp = function(dt, $ts) {
+				console.log(dt);
 				var year = parseInt(dt.year.val()),
 					month = parseInt(dt.month.val())-1,
 					day = parseInt(dt.day.val()),
@@ -32,10 +33,11 @@ const managerHTML = `
 
 					if (dt.period === "PM") {
 						hour = hour + 12;
+						console.log(hour);
 					}
 
 				var date = new Date(year, month, day, hour, minute);
-				
+				console.log(date);
 				$ts.val(date.getTime());
 			}
 

--- a/management/manager/manager.go
+++ b/management/manager/manager.go
@@ -30,15 +30,12 @@ const managerHTML = `
 					hour = parseInt(dt.hour.val()),
 					minute = parseInt(dt.minute.val());
 
-					console.log(year, month, day, hour, minute);
-
 					if (dt.period.val() === "PM") {
 						hour = hour + 12;
-						console.log(hour);
 					}
 
 				var date = new Date(year, month, day, hour, minute);
-				console.log(date);
+				
 				$ts.val(date.getTime());
 			}
 

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -97,6 +97,10 @@ func (c *Config) MarshalEditor() ([]byte, error) {
 				right: '0px'
 			});
 
+			var contentOnly = $('.content-only.__ponzu');
+			contentOnly.hide();
+			contentOnly.find('input, textarea, select').attr('name', '');
+
 			// adjust layout of td so save button is in same location as usual
 			fields.find('td').css('float', 'right');
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -340,7 +340,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 										var s = sort.val();
 										var t = getParam("type");
 
-										window.location.replace(path + "&type=" + t + "&order=" + s)
+										window.location.replace(path + "?type=" + t + "&order=" + s)
 									});
 
 									var order = getParam("order");

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -452,7 +452,7 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 
-				<form class="quick-delete-post __ponzu right" action="/admin/edit/delete method="post">
+				<form class="quick-delete-post __ponzu right" action="/admin/edit/delete" method="post">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
 					<input type="hidden" name="type" value="` + t + `" />

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -428,14 +428,14 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 	// use sort to get other info to display in admin UI post list
 	tsTime := time.Unix(int64(s.Time()/1000), 0)
 	upTime := time.Unix(int64(s.Touch()/1000), 0)
-	updatedTime := upTime.Format("Jan 2, 2006 15:04 PM")
-	publishTime := tsTime.Format("1/2/06")
+	updatedTime := upTime.Format("01/02/06 03:04 PM")
+	publishTime := tsTime.Format("01/02/06")
 
 	post := `
 			<li class="col s12">
 				<a href="/admin/edit?type=` + t + `&id=` + fmt.Sprintf("%d", p.ContentID()) + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
-				<span class="right">Updated: ` + publishTime + `</span>
+				<span class="right">` + publishTime + `</span>
 			</li>`
 
 	return []byte(post)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -694,10 +694,16 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		json.Unmarshal(posts[i], &p)
-		post := `<li class="col s12"><a href="/admin/edit?type=` +
-			t + `&id=` + fmt.Sprintf("%d", p.ContentID()) +
-			`">` + p.ContentName() + `</a></li>`
+		err := json.Unmarshal(posts[i], &p)
+		if err != nil {
+			log.Println("Error unmarshal search result json into", t, err, posts[i])
+
+			post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
+			b.Write([]byte(post))
+			continue
+		}
+
+		post := adminPostListItem(p, t)
 		b.Write([]byte(post))
 	}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -438,7 +438,7 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 				<a href="/admin/edit?type=` + t + `&id=` + cid + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<form class="quick-delete-post __ponzu" action="/admin/edit/delete">
-					<i class="small material-icons red">delete</i>
+					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
 					<input type="hidden" name="type" value="` + t + `" />
 				</form>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -498,6 +498,8 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
+		go db.SortContent(t)
+
 		scheme := req.URL.Scheme
 		host := req.URL.Host
 		path := req.URL.Path

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -639,6 +639,7 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 
 	err := req.ParseMultipartForm(1024 * 1024 * 4) // maxMemory 4MB
 	if err != nil {
+		fmt.Println("req.ParseMPF")
 		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -653,6 +654,7 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 
 	err = db.DeleteContent(t + ":" + id)
 	if err != nil {
+		fmt.Println("db.DeleteContent")
 		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -289,7 +289,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	posts := db.ContentAll(t)
+	order := strings.ToLower(q.Get("order"))
+
+	posts := db.ContentAll(t + "_sorted")
 	b := &bytes.Buffer{}
 	p, ok := content.Types[t]().(editor.Editable)
 	if !ok {
@@ -363,12 +365,24 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					</div>
 					<ul class="posts row">`
 
-	for i := range posts {
-		json.Unmarshal(posts[i], &p)
-		post := `<li class="col s12"><a href="/admin/edit?type=` +
-			t + `&id=` + fmt.Sprintf("%d", p.ContentID()) +
-			`">` + p.ContentName() + `</a></li>`
-		b.Write([]byte(post))
+	if order == "desc" || order == "" {
+		// keep natural order of posts slice, as returned from sorted bucket
+		for i := range posts {
+			json.Unmarshal(posts[i], &p)
+			post := `<li class="col s12"><a href="/admin/edit?type=` +
+				t + `&id=` + fmt.Sprintf("%d", p.ContentID()) +
+				`">` + p.ContentName() + `</a></li>`
+			b.Write([]byte(post))
+		}
+	} else if order == "asc" {
+		// reverse the order of posts slice
+		for i := len(posts) - 1; i >= 0; i-- {
+			json.Unmarshal(posts[i], &p)
+			post := `<li class="col s12"><a href="/admin/edit?type=` +
+				t + `&id=` + fmt.Sprintf("%d", p.ContentID()) +
+				`">` + p.ContentName() + `</a></li>`
+			b.Write([]byte(post))
+		}
 	}
 
 	b.Write([]byte(`</ul></div></div>`))

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -498,8 +498,6 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		go db.SortContent(t)
-
 		scheme := req.URL.Scheme
 		host := req.URL.Host
 		path := req.URL.Path

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -437,6 +437,8 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="right">Updated: ` + publishTime + `</span>
 			</li>`
+
+	return []byte(post)
 }
 
 func editHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -314,7 +314,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 									<option value="DESC">New to Old</option>
 									<option value="ASC">Old to New</option>
 								</select>
-								<label>Sort:</label>
+								<label class="active">Sort:</label>
 							</div>	
 							<script>
 								$(function() {
@@ -354,8 +354,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					</div>
 					<form class="col s5" action="/admin/posts/search" method="get">
 						<div class="input-field post-search inline">
+							<label class="active">Search</label>
 							<i class="right material-icons search-icon">search</i>
-							<input class="search" name="q" type="text" placeholder="Search for ` + t + ` content" class="search"/>
+							<input class="search" name="q" type="text" placeholder="Within ` + t + ` fields" class="search"/>
 							<input type="hidden" name="type" value="` + t + `" />
 						</div>
                     </form>	

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -306,7 +306,52 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	html := `<div class="col s9 card">		
 					<div class="card-content">
 					<div class="row">
-					<div class="card-title col s7">` + t + ` Items</div>	
+					<div class="col s7">
+						<div class="row">
+							<div class="card-title col s7">` + t + ` Items</div>
+							<div class="col s5 input-field inline">
+								<select class="browser-default __ponzu sort-order">
+									<option value="DESC">New to Old</option>
+									<option value="ASC">Old to New</option>
+								</select>
+								<label>Sort:</label>
+							</div>	
+							<script>
+								$(function() {
+									var getParam = function(param) {
+										var qs = window.location.search.substring(1);
+										var qp = qs.split("&");
+										var t = "";
+
+										for (var i = 0; i < qp.length; i++) {
+											var p = qp[i].split("=")
+											if (p[0] === param) {
+												t = p[1];	
+											}
+										}
+
+										return t;
+									}
+
+									var sort = $('select.__ponzu.sort-order');
+
+									sort.on('change', function() {
+										var path = window.location.pathname;
+										var s = sort.val();
+										var t = getParam("type");
+
+										window.location.replace(path + "&type=" + t + "&order=" + s)
+									});
+
+									var order = getParam("order");
+									if (order !== "") {
+										sort.val(order);
+									}
+									
+								});
+							</script>
+						</div>
+					</div>
 					<form class="col s5" action="/admin/posts/search" method="get">
 						<div class="input-field post-search inline">
 							<i class="right material-icons search-icon">search</i>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -452,7 +452,7 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 
-				<form class="quick-delete-post __ponzu right" action="/admin/edit/delete">
+				<form class="quick-delete-post __ponzu right" action="/admin/edit/delete method="post">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
 					<input type="hidden" name="type" value="` + t + `" />

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -401,8 +401,21 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 	b.Write([]byte(`</ul></div></div>`))
 
+	script := `
+	<script>
+		$(function() {
+			var del = $('.quick-delete-post.__ponzu span');
+			del.on('click', function(e) {
+				if (confirm("[Ponzu] Please confirm:\n\nAre you sure you want to delete this post?\nThis cannot be undone.")) {
+					$(e.target).parent().submit();
+				}
+			});
+		});
+	</script>
+	`
+
 	btn := `<div class="col s3"><a href="/admin/edit?type=` + t + `" class="btn new-post waves-effect waves-light">New ` + t + `</a></div></div>`
-	html = html + b.String() + btn
+	html = html + b.String() + script + btn
 
 	adminView, err := Admin([]byte(html))
 	if err != nil {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -437,12 +437,13 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 			<li class="col s12">
 				<a href="/admin/edit?type=` + t + `&id=` + cid + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
-				<form class="quick-delete-post __ponzu" action="/admin/edit/delete">
+				<span class="publish-date right">` + publishTime + `</span>
+
+				<form class="quick-delete-post __ponzu right" action="/admin/edit/delete">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
 					<input type="hidden" name="type" value="` + t + `" />
 				</form>
-				<span class="right">` + publishTime + `</span>
 			</li>`
 
 	return []byte(post)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -309,7 +309,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	html := `<div class="col s9 card">		
 					<div class="card-content">
 					<div class="row">
-					<div class="col s7">
+					<div class="col s8">
 						<div class="row">
 							<div class="card-title col s7">` + t + ` Items</div>
 							<div class="col s5 input-field inline">
@@ -323,11 +323,11 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 								$(function() {
 									var getParam = function(param) {
 										var qs = window.location.search.substring(1);
-										var qp = qs.split("&");
-										var t = "";
+										var qp = qs.split('&');
+										var t = '';
 
 										for (var i = 0; i < qp.length; i++) {
-											var p = qp[i].split("=")
+											var p = qp[i].split('=')
 											if (p[0] === param) {
 												t = p[1];	
 											}
@@ -341,13 +341,13 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 									sort.on('change', function() {
 										var path = window.location.pathname;
 										var s = sort.val();
-										var t = getParam("type");
+										var t = getParam('type');
 
-										window.location.replace(path + "?type=" + t + "&order=" + s)
+										window.location.replace(path + '?type=' + t + '&order=' + s)
 									});
 
-									var order = getParam("order");
-									if (order !== "") {
+									var order = getParam('order');
+									if (order !== '') {
 										sort.val(order);
 									}
 									
@@ -355,7 +355,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 							</script>
 						</div>
 					</div>
-					<form class="col s5" action="/admin/posts/search" method="get">
+					<form class="col s4" action="/admin/posts/search" method="get">
 						<div class="input-field post-search inline">
 							<label class="active">Search:</label>
 							<i class="right material-icons search-icon">search</i>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -452,7 +452,7 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 
-				<form class="quick-delete-post __ponzu right" action="/admin/edit/delete" method="post">
+				<form enctype="multipart/form-data" class="quick-delete-post __ponzu right" action="/admin/edit/delete" method="post">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
 					<input type="hidden" name="type" value="` + t + `" />

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -431,10 +431,17 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 	updatedTime := upTime.Format("01/02/06 03:04 PM")
 	publishTime := tsTime.Format("01/02/06")
 
+	cid := fmt.Sprintf("%d", p.ContentID())
+
 	post := `
 			<li class="col s12">
-				<a href="/admin/edit?type=` + t + `&id=` + fmt.Sprintf("%d", p.ContentID()) + `">` + p.ContentName() + `</a>
+				<a href="/admin/edit?type=` + t + `&id=` + cid + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
+				<form class="quick-delete-post __ponzu" action="/admin/edit/delete">
+					<i class="small material-icons red">delete</i>
+					<input type="hidden" name="id" value="` + cid + `" />
+					<input type="hidden" name="type" value="` + t + `" />
+				</form>
 				<span class="right">` + publishTime + `</span>
 			</li>`
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -358,7 +358,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 						<div class="input-field post-search inline">
 							<label class="active">Search:</label>
 							<i class="right material-icons search-icon">search</i>
-							<input class="search" name="q" type="text" placeholder="Within all` + t + ` fields" class="search"/>
+							<input class="search" name="q" type="text" placeholder="Within all ` + t + ` fields" class="search"/>
 							<input type="hidden" name="type" value="` + t + `" />
 						</div>
                     </form>	

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -354,9 +354,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					</div>
 					<form class="col s5" action="/admin/posts/search" method="get">
 						<div class="input-field post-search inline">
-							<label class="active">Search</label>
+							<label class="active">Search:</label>
 							<i class="right material-icons search-icon">search</i>
-							<input class="search" name="q" type="text" placeholder="Within ` + t + ` fields" class="search"/>
+							<input class="search" name="q" type="text" placeholder="Within all` + t + ` fields" class="search"/>
 							<input type="hidden" name="type" value="` + t + `" />
 						</div>
                     </form>	

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -164,6 +164,18 @@ span.post-detail {
     font-style: italic;  
 }
 
+.quick-delete-post {
+    display: none;
+}
+
+li:hover .quick-delete-post {
+    display: block;
+}
+
+.quick-delete-post i {
+    cursor: pointer;
+}
+
 
 /* OVERRIDE Bootstrap + Materialize conflicts */
 .iso-texteditor.input-field label {

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -169,11 +169,13 @@ span.post-detail {
 }
 
 li:hover .quick-delete-post {
-    display: block;
+    display: inline-block;
 }
 
-.quick-delete-post i {
+.quick-delete-post span {
     cursor: pointer;
+    color: #F44336;
+    text-transform: uppercase;
 }
 
 

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -158,6 +158,12 @@ footer p {
     margin-left: 10px;
 }
 
+span.post-detail {
+    font-size: 11px;
+    color: #9e9e9e;
+    font-style: italic;  
+}
+
 
 /* OVERRIDE Bootstrap + Materialize conflicts */
 .iso-texteditor.input-field label {

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -176,6 +176,8 @@ li:hover .quick-delete-post {
     cursor: pointer;
     color: #F44336;
     text-transform: uppercase;
+    font-size: 11px;
+    font-weight: bold;
 }
 
 

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -178,6 +178,7 @@ li:hover .quick-delete-post {
     text-transform: uppercase;
     font-size: 11px;
     font-weight: bold;
+    margin-right: 20px;
 }
 
 

--- a/system/admin/static/editor/js/materialNote.js
+++ b/system/admin/static/editor/js/materialNote.js
@@ -6108,7 +6108,7 @@ var dom = (function() {
         var hasDefaultFont = agent.isFontInstalled(options.defaultFontName);
         var defaultFontName = (hasDefaultFont) ? options.defaultFontName : realFontList[0];
         var label = '<div class="note-current-fontname">' + defaultFontName + '</div>';
-        console.log('editing right file...')
+        // console.log('editing right file...')
         return tplButton(label, {
           title: lang.font.name,
           className: 'note-fontname',
@@ -6886,7 +6886,7 @@ var dom = (function() {
                 var isFullscreen = $editor.hasClass('fullscreen');
 
                 if (isFullscreen) {
-                  console.log("fullscreen");
+                  // console.log("fullscreen");
                   return false;
                 }
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -265,7 +265,7 @@ func SortContent(namespace string) {
 		return nil
 	})
 	if err != nil {
-		log.Println("Error while updating db with sorted", namespace)
+		log.Println("Error while updating db with sorted", namespace, err)
 	}
 
 }

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -65,6 +65,8 @@ func update(ns, id string, data url.Values) (int, error) {
 		return 0, nil
 	}
 
+	go SortContent(ns)
+
 	return cid, nil
 }
 
@@ -104,6 +106,8 @@ func insert(ns string, data url.Values) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	go SortContent(ns)
 
 	return effectedID, nil
 }
@@ -153,6 +157,8 @@ func DeleteContent(target string) error {
 	if err != nil {
 		return err
 	}
+
+	go SortContent(ns)
 
 	return nil
 }

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -211,10 +211,11 @@ func SortContent(namespace string) {
 	fmt.Println(all)
 
 	var posts sortablePosts
-	post := content.Types[namespace]()
 	// decode each (json) into Editable
 	for i := range all {
 		j := all[i]
+		post := content.Types[namespace]()
+
 		err := json.Unmarshal(j, &post)
 		if err != nil {
 			log.Println("Error decoding json while sorting", namespace, ":", err)

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -251,7 +251,7 @@ func (s sortablePosts) Len() int {
 }
 
 func (s sortablePosts) Less(i, j int) bool {
-	return s[i].Time() < s[j].Time()
+	return s[i].Time() > s[j].Time()
 }
 
 func (s sortablePosts) Swap(i, j int) {

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -222,13 +222,13 @@ func SortContent(namespace string) {
 		posts = append(posts, post.(editor.Sortable))
 	}
 
-	fmt.Println(posts)
+	fmt.Printf("%#v\n", posts)
 	fmt.Println("------------------------NOW SORTED------------------------")
 
 	// sort posts
 	sort.Sort(posts)
 
-	fmt.Println(posts)
+	fmt.Printf("%#v\n", posts)
 
 	// one by one, encode to json and store as
 	// store in __sorted bucket inside namespace bucket, first delete existing

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -232,14 +232,14 @@ func SortContent(namespace string) {
 	fmt.Println("------------------------NOW SORTED------------------------")
 
 	// sort posts
-	sort.Sort(&posts)
+	sort.Sort(posts)
 
 	for i := range posts {
 		fmt.Printf("%v\n", posts[i])
 	}
 
 	// one by one, encode to json and store as
-	// store in __sorted bucket inside namespace bucket, first delete existing
+	// store in <namespace>__sorted bucket, first delete existing
 
 }
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -245,14 +245,14 @@ func SortContent(namespace string) {
 			return err
 		}
 
-		// encode to json and store as post.Time():post
-		for _, post := range posts {
-			j, err := json.Marshal(post)
+		// encode to json and store as i-post.Time():post
+		for i := range posts {
+			j, err := json.Marshal(posts[i])
 			if err != nil {
 				return err
 			}
 
-			cid := fmt.Sprintf("%d-%d", post.Time(), post.ContentID())
+			cid := fmt.Sprintf("%d:%d", i, posts[i].Time())
 			err = b.Put([]byte(cid), j)
 			if err != nil {
 				err := tx.Rollback()

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -158,7 +158,11 @@ func DeleteContent(target string) error {
 		return err
 	}
 
-	go SortContent(ns)
+	// exception to typical "run in goroutine" pattern:
+	// we want to have an updated admin view as soon as this is deleted, so
+	// in some cases, the delete and redirect is faster than the sort,
+	// thus still showing a deleted post in the admin view.
+	SortContent(ns)
 
 	return nil
 }

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -222,13 +222,13 @@ func SortContent(namespace string) {
 		posts = append(posts, post.(editor.Sortable))
 	}
 
-	fmt.Printf("%#v\n", posts)
+	fmt.Printf("%v\n", posts)
 	fmt.Println("------------------------NOW SORTED------------------------")
 
 	// sort posts
 	sort.Sort(posts)
 
-	fmt.Printf("%#v\n", posts)
+	fmt.Printf("%v\n", posts)
 
 	// one by one, encode to json and store as
 	// store in __sorted bucket inside namespace bucket, first delete existing

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -222,13 +222,19 @@ func SortContent(namespace string) {
 		posts = append(posts, post.(editor.Sortable))
 	}
 
-	fmt.Printf("%v\n", posts)
+	fmt.Println("-------------------------UN-SORTED------------------------")
+
+	for i := range posts {
+		fmt.Printf("%v\n", posts[i])
+	}
 	fmt.Println("------------------------NOW SORTED------------------------")
 
 	// sort posts
 	sort.Sort(posts)
 
-	fmt.Printf("%v\n", posts)
+	for i := range posts {
+		fmt.Printf("%v\n", posts[i])
+	}
 
 	// one by one, encode to json and store as
 	// store in __sorted bucket inside namespace bucket, first delete existing

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -245,14 +245,14 @@ func SortContent(namespace string) {
 			return err
 		}
 
-		// encode to json and store as post.ID:post
+		// encode to json and store as post.Time():post
 		for _, post := range posts {
 			j, err := json.Marshal(post)
 			if err != nil {
 				return err
 			}
 
-			cid := fmt.Sprintf("%d", post.ContentID())
+			cid := fmt.Sprintf("%d-%d", post.Time(), post.ContentID())
 			err = b.Put([]byte(cid), j)
 			if err != nil {
 				err := tx.Rollback()

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -208,6 +208,8 @@ func ContentAll(namespace string) [][]byte {
 func SortContent(namespace string) {
 	all := ContentAll(namespace)
 
+	fmt.Println(all)
+
 	var posts sortablePosts
 	post := content.Types[namespace]()
 	// decode each (json) into Editable
@@ -230,7 +232,7 @@ func SortContent(namespace string) {
 	fmt.Println("------------------------NOW SORTED------------------------")
 
 	// sort posts
-	sort.Sort(posts)
+	sort.Sort(&posts)
 
 	for i := range posts {
 		fmt.Printf("%v\n", posts[i])

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -208,8 +208,6 @@ func ContentAll(namespace string) [][]byte {
 func SortContent(namespace string) {
 	all := ContentAll(namespace)
 
-	fmt.Println(all)
-
 	var posts sortablePosts
 	// decode each (json) into Editable
 	for i := range all {
@@ -245,7 +243,7 @@ func SortContent(namespace string) {
 			return err
 		}
 
-		// encode to json and store as i-post.Time():post
+		// encode to json and store as 'i:post.Time()':post
 		for i := range posts {
 			j, err := json.Marshal(posts[i])
 			if err != nil {

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -33,8 +33,6 @@ func Init() {
 			if err != nil {
 				return err
 			}
-
-			go SortContent(t + "_sorted")
 		}
 
 		// init db with other buckets as needed
@@ -70,6 +68,11 @@ func Init() {
 	})
 	if err != nil {
 		log.Fatal("Coudn't initialize db with buckets.", err)
+	}
+
+	// sort all content into type_sorted buckets
+	for t := range content.Types {
+		go SortContent(t + "_sorted")
 	}
 
 }

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -73,7 +73,7 @@ func Init() {
 	// sort all content into type_sorted buckets
 	go func() {
 		for t := range content.Types {
-			SortContent(t + "_sorted")
+			SortContent(t)
 		}
 	}()
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -71,9 +71,11 @@ func Init() {
 	}
 
 	// sort all content into type_sorted buckets
-	for t := range content.Types {
-		go SortContent(t + "_sorted")
-	}
+	go func() {
+		for t := range content.Types {
+			SortContent(t + "_sorted")
+		}
+	}()
 
 }
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -22,9 +22,14 @@ func Init() {
 	}
 
 	err = store.Update(func(tx *bolt.Tx) error {
-		// initialize db with all content type buckets
+		// initialize db with all content type buckets & sorted bucket for type
 		for t := range content.Types {
 			_, err := tx.CreateBucketIfNotExists([]byte(t))
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.CreateBucketIfNotExists([]byte(t + "_sorted"))
 			if err != nil {
 				return err
 			}

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -33,6 +33,8 @@ func Init() {
 			if err != nil {
 				return err
 			}
+
+			go SortContent(t + "_sorted")
 		}
 
 		// init db with other buckets as needed


### PR DESCRIPTION
This PR adds a few things: 
1. Content type posts sortable by time (via the `editor.Sortable` interface) 
2. Implementation of sorting inside Admin 
3. Quick delete of post from post list and search results

Since sorting can take some time when db size is large, it is _almost_ always done in its own goroutine, with the exception of the admin delete handler. Additionally, to avoid re-sorting content posts per API query, we keep a sorted bucket of posts in the db to be quickly retrieved. This sorted bucket is re-created each time new content is added, edited, or deleted.

With regards to the `Sortable` interface, there is some overlap with the `Editable` interface. In at least one occasion, I do a type assertion in the same function from a content type to `Editable` then again later from a content type to `Sortable`. Since the two interfaces currently share a method in their sets (`ContentID() int`) , I'm wondering if it is worth adding a 3rd compound interface `SortEditable` or similar... 

Here are the two interface types for reference: 
```go
// Editable ensures data is editable
type Editable interface {
	SetContentID(id int)
	ContentID() int
	ContentName() string
	SetSlug(slug string)
	Editor() *Editor
	MarshalEditor() ([]byte, error)
}

// Sortable ensures data is sortable by time
type Sortable interface {
	Time() int64
	Touch() int64
	ContentID() int
}
```

Any feedback on this would be helpful!