### PR TITLE
[core] Adding input func for Tags

### DIFF
--- a/cmd/ponzu/options.go
+++ b/cmd/ponzu/options.go
@@ -72,12 +72,12 @@ type {{ .name }} struct {
 	editor editor.Editor
 
     // required: all maintained {{ .name }} fields must have json tags!
-	Title      string ` + "`json:" + `"title"` + "`" + `
-	Content    string ` + "`json:" + `"content"` + "`" + `
-	Author     string ` + "`json:" + `"author"` + "`" + `
-	Picture    string ` + "`json:" + `"picture"` + "`" + `	
-	Category   []string ` + "`json:" + `"category"` + "`" + `
-	ThemeStyle string ` + "`json:" + `"theme"` + "`" + `
+	Title    string ` + "`json:" + `"title"` + "`" + `
+	Content  string ` + "`json:" + `"content"` + "`" + `
+	Author   string ` + "`json:" + `"author"` + "`" + `
+	Photo    string ` + "`json:" + `"picture"` + "`" + `	
+	Category []string ` + "`json:" + `"category"` + "`" + `
+	Theme	 string ` + "`json:" + `"theme"` + "`" + `
 }
 
 func init() {
@@ -101,7 +101,6 @@ func ({{ .initial }} *{{ .name }}) Editor() *editor.Editor { return &{{ .initial
 
 // MarshalEditor writes a buffer of html to edit a {{ .name }} and partially implements editor.Editable
 func ({{ .initial }} *{{ .name }}) MarshalEditor() ([]byte, error) {
-/* EXAMPLE CODE (from post.go, the default content type) */
 	view, err := editor.Form({{ .initial }},
 		editor.Field{
 			// Take careful note that the first argument to these Input-like methods 
@@ -127,22 +126,18 @@ func ({{ .initial }} *{{ .name }}) MarshalEditor() ([]byte, error) {
 			}),
 		},
 		editor.Field{
-			View: editor.File("Picture", {{ .initial }}, map[string]string{
+			View: editor.File("Photo", {{ .initial }}, map[string]string{
 				"label":       "Author Photo",
 				"placeholder": "Upload a profile picture for the author",
 			}),
 		},
 		editor.Field{
-			View: editor.Checkbox("Category", {{ .initial }}, map[string]string{
+			View: editor.Tags("Category", {{ .initial }}, map[string]string{
 				"label": "{{ .name }} Category",
-			}, map[string]string{
-				"important": "Important",
-				"active":    "Active",
-				"unplanned": "Unplanned",
 			}),
 		},
 		editor.Field{
-			View: editor.Select("ThemeStyle", {{ .initial }}, map[string]string{
+			View: editor.Select("Theme", {{ .initial }}, map[string]string{
 				"label": "Theme Style",
 			}, map[string]string{
 				"dark": "Dark",

--- a/content/post.go
+++ b/content/post.go
@@ -11,12 +11,12 @@ type Post struct {
 	Item
 	editor editor.Editor
 
-	Title      string   `json:"title"`
-	Content    string   `json:"content"`
-	Photo      string   `json:"photo"`
-	Author     string   `json:"author"`
-	Category   []string `json:"category"`
-	ThemeStyle string   `json:"theme"`
+	Title    string   `json:"title"`
+	Content  string   `json:"content"`
+	Photo    string   `json:"photo"`
+	Author   string   `json:"author"`
+	Category []string `json:"category"`
+	Theme    string   `json:"theme"`
 }
 
 func init() {
@@ -55,7 +55,7 @@ func (p *Post) MarshalEditor() ([]byte, error) {
 			}),
 		},
 		editor.Field{
-			View: editor.File("Picture", p, map[string]string{
+			View: editor.File("Photo", p, map[string]string{
 				"label":       "Author Photo",
 				"placeholder": "Upload a profile picture for the author",
 			}),
@@ -73,7 +73,7 @@ func (p *Post) MarshalEditor() ([]byte, error) {
 			}),
 		},
 		editor.Field{
-			View: editor.Select("ThemeStyle", p, map[string]string{
+			View: editor.Select("Theme", p, map[string]string{
 				"label": "Theme Style",
 			}, map[string]string{
 				"dark":  "Dark",

--- a/content/post.go
+++ b/content/post.go
@@ -68,12 +68,8 @@ func (p *Post) MarshalEditor() ([]byte, error) {
 			}),
 		},
 		editor.Field{
-			View: editor.Checkbox("Category", p, map[string]string{
-				"label": "Post Category",
-			}, map[string]string{
-				"important": "Important",
-				"active":    "Active",
-				"unplanned": "Unplanned",
+			View: editor.Tags("Category", p, map[string]string{
+				"label": "Post Categories",
 			}),
 		},
 		editor.Field{

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -375,7 +375,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				var input = $('<input>');
 				input.attr({
 					class: 'tag-'+chip.tag,
-					name: '` + name + `.'+tags.find('input[type=hidden]').length-1,
+					name: '` + name + `.'+String(tags.find('input[type=hidden]').length),
 					value: chip.tag,
 					type: 'hidden'
 				});

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -364,7 +364,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var tags = $('.tags.` + name + `');
 			$('.chips.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `],
-				secondaryPlaceholder: '+'` + name + `
+				secondaryPlaceholder: '+More'
 			});		
 
 			// handle events specific to tags
@@ -372,7 +372,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			
 			chips.on('chip.add', function(e, chip) {
 				console.log("id:", tags.find('input[type=hidden]').length-1);
-				var input = $('<Input>');
+				var input = $('<input>');
 				input.attr({
 					class: 'tag-'+chip.tag,
 					name: '` + name + `.'+tags.find('input[type=hidden]').length-1,

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -345,7 +345,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 	html := `
 	<div class="input-field col s12 tags ` + name + `">
-		<div class="chips` + name + `"></div>
+		<div class="chips ` + name + `"></div>
 	`
 
 	var initial []string
@@ -361,7 +361,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	<script>
 		$(function() {
 			var tags = $('.tags.` + name + `');
-			$('.chips` + name + `').material_chip({
+			$('.chips.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `],
 				placeholder: '` + attrs["label"] + `',
 				secondaryPlaceholder: 'Type and press "Enter" to add ` + name + `'

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -387,6 +387,12 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				console.log(sel);
 				console.log(chips.parent().find(sel));				
 				chips.parent().find(sel).remove();
+
+				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index
+				var hidden = chips.parent().find('input[type=hidden]');
+				for (var i = 0; i < hidden.length; i++) {
+					hidden[i].attr('name', '` + name + `.'+String(i));
+				}
 			});
 		});
 	</script>

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -345,6 +345,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 	html := `
 	<div class="input-field col s12 tags ` + name + `">
+		<label class="active">` + attrs["label"] + `</label>
 		<div class="chips ` + name + `"></div>
 	`
 
@@ -363,8 +364,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var tags = $('.tags.` + name + `');
 			$('.chips.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `],
-				placeholder: '` + attrs["label"] + `',
-				secondaryPlaceholder: 'Type and press "Enter" to add ` + name + `'
+				placeholder: 'Type and press "Enter" to add ` + name + `'
 			});		
 
 			// handle events specific to tags
@@ -384,7 +384,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				var sel = '.tag-'+chip.tag;
-				$(sel).remove();
+				chips.parent().find(sel).remove();
 			});
 		});
 	</script>

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -385,7 +385,9 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			});
 
 			chips.on('chip.delete', function(e, chip) {
-				var sel = '.tag-'+chip.tag;				
+				var sel = '.tag-'+chip.tag;	
+				console.log(sel);
+				console.log(chips.parent().find(sel));			
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index
@@ -397,7 +399,6 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 					input.attr({
 						class: 'empty-tag',
 						name: '` + name + `',
-						value: "",
 						type: 'hidden'
 					});
 					

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -375,7 +375,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				
 				var input = $('<input>');
 				input.attr({
-					class: 'tag-'+chip.tag,
+					class: 'tag '+chip.tag,
 					name: '` + name + `.'+String(tags.find('input[type=hidden]').length),
 					value: chip.tag,
 					type: 'hidden'
@@ -385,7 +385,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			});
 
 			chips.on('chip.delete', function(e, chip) {
-				var sel = '.tag-'+chip.tag;	
+				// convert tag string to class-like selector "some tag" -> ".some.tag"
+				var sel = '.tag.'+chip.tag.split(' ').join('.');	
 				console.log(sel);
 				console.log(chips.parent().find(sel));			
 				chips.parent().find(sel).remove();

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -344,8 +344,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	tags := values.Slice(0, values.Len()).Interface().([]string) // casts reflect.Value to []string
 
 	html := `
-	<div class="input-field col s12 tags ` + name + `">
-		<label class="active">` + attrs["label"] + `</label>
+	<div class="col s12 tags ` + name + `">
+		<label class="active">` + attrs["label"] + ` (Type and press "Enter")</label>
 		<div class="chips ` + name + `"></div>
 	`
 
@@ -364,14 +364,15 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var tags = $('.tags.` + name + `');
 			$('.chips.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `],
-				placeholder: 'Type and press "Enter" to add ` + name + `'
+				secondaryPlaceholder: '+'` + name + `
 			});		
 
 			// handle events specific to tags
 			var chips = tags.find('.chips');
 			
 			chips.on('chip.add', function(e, chip) {
-				var input = $('<input>');
+				console.log("id:", tags.find('input[type=hidden]').length-1);
+				var input = $('<Input>');
 				input.attr({
 					class: 'tag-'+chip.tag,
 					name: '` + name + `.'+tags.find('input[type=hidden]').length-1,

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -345,9 +345,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 	html := `
 	<div class="input-field col s12 tags ` + name + `">
-	<div class="chips ` + name + `"></div>
-	<div class="chips chips-initial ` + name + `"></div>	
-	<div class="chips chips-placeholder ` + name + `"></div>
+		<div class="chips` + name + `"></div>
 	`
 
 	var initial []string
@@ -363,14 +361,11 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	<script>
 		$(function() {
 			var tags = $('.tags.` + name + `');
-			$('.chips.` + name + `').material_chip();
-			$('.chips-initial.` + name + `').material_chip({
-				data: [` + strings.Join(initial, ",") + `]
-			});
-			$('.chips-placeholder.` + name + `').material_chip({
+			$('.chips` + name + `').material_chip({
+				data: [` + strings.Join(initial, ",") + `],
 				placeholder: '` + attrs["label"] + `',
-				secondaryPlaceholder: 'Type and press "Enter" to add ` + name + `',
-			});			
+				secondaryPlaceholder: 'Type and press "Enter" to add ` + name + `'
+			});		
 
 			// handle events specific to tags
 			var chips = tags.find('.chips');

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -368,8 +368,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				data: [` + strings.Join(initial, ",") + `]
 			});
 			$('.chips-placeholder.` + name + `').material_chip({
-				placeholder: ` + attrs["label"] + `,
-				secondaryPlaceholder: Type and press 'Enter' to add ` + name + `,
+				placeholder: '` + attrs["label"] + `',
+				secondaryPlaceholder: 'Type and press "Enter" to add ` + name + `',
 			});			
 
 			// handle events specific to tags

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -371,7 +371,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var chips = tags.find('.chips');
 			
 			chips.on('chip.add', function(e, chip) {
-				tags.find('.empty-tag').remove();
+				chips.parent().find('.empty-tag').remove();
 				
 				var input = $('<input>');
 				input.attr({
@@ -385,9 +385,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			});
 
 			chips.on('chip.delete', function(e, chip) {
-				var sel = '.tag-'+chip.tag;
-				console.log(sel);
-				console.log(chips.parent().find(sel));				
+				var sel = '.tag-'+chip.tag;				
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -354,7 +354,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	for _, tag := range tags {
 		tagName := tagNameFromStructFieldMulti(fieldName, i, p)
 		html += `<input type="hidden" class="tag-` + tag + `" name=` + tagName + ` value="` + tag + `"/>`
-		initial = append(initial, `{tag: `+tag+`}`)
+		initial = append(initial, `{tag: '`+tag+`'}`)
 		i++
 	}
 
@@ -364,14 +364,13 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var tags = $('.tags.` + name + `');
 			$('.chips.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `],
-				secondaryPlaceholder: '+More'
+				secondaryPlaceholder: '+ '` + name + `
 			});		
 
 			// handle events specific to tags
 			var chips = tags.find('.chips');
 			
 			chips.on('chip.add', function(e, chip) {
-				console.log("id:", tags.find('input[type=hidden]').length-1);
 				var input = $('<input>');
 				input.attr({
 					class: 'tag-'+chip.tag,

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -371,7 +371,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var chips = tags.find('.chips');
 			
 			chips.on('chip.add', function(e, chip) {
-				var input = $('input');
+				var input = $('<input>');
 				input.attr({
 					class: 'tag-'+chip.tag,
 					name: '` + name + `.'+tags.find('input[type=hidden]').length-1,

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -391,7 +391,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index
 				var hidden = chips.parent().find('input[type=hidden]');
 				for (var i = 0; i < hidden.length; i++) {
-					hidden[i].attr('name', '` + name + `.'+String(i));
+					$(hidden[i]).attr('name', '` + name + `.'+String(i));
 				}
 			});
 		});

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -384,6 +384,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				var sel = '.tag-'+chip.tag;
+				console.log(sel);
+				console.log(chips.parent().find(sel));				
 				chips.parent().find(sel).remove();
 			});
 		});

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -363,11 +363,11 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	<script>
 		$(function() {
 			var tags = $('.tags.` + name + `');
-			$('.chips.` + name + `).material_chip();
-			$('.chips-initial.` + name + `).material_chip({
+			$('.chips.` + name + `').material_chip();
+			$('.chips-initial.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `]
 			});
-			$('.chips-placeholder.` + name + `).material_chip({
+			$('.chips-placeholder.` + name + `').material_chip({
 				placeholder: ` + attrs["label"] + `,
 				secondaryPlaceholder: Type and press 'Enter' to add ` + name + `,
 			});			
@@ -379,7 +379,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				var input = $('input');
 				input.attr({
 					class: 'tag-'+chip.tag,
-					name: '` + name + `.'+tags.find('input[type=hidden]).length-1,
+					name: '` + name + `.'+tags.find('input[type=hidden]').length-1,
 					value: chip.tag,
 					type: 'hidden'
 				});

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -371,6 +371,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var chips = tags.find('.chips');
 			
 			chips.on('chip.add', function(e, chip) {
+				tags.find('.empty-tag').remove();
+				
 				var input = $('<input>');
 				input.attr({
 					class: 'tag-'+chip.tag,
@@ -390,6 +392,21 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index
 				var hidden = chips.parent().find('input[type=hidden]');
+				
+				// if there are no tags, set a blank
+				if (hidden.length === 0) {
+					var input = $('<input>');
+					input.attr({
+						class: 'empty-tag',
+						name: '` + name + `',
+						value: "",
+						type: 'hidden'
+					});
+					
+					tags.append(input);
+					return;
+				}
+				
 				for (var i = 0; i < hidden.length; i++) {
 					$(hidden[i]).attr('name', '` + name + `.'+String(i));
 				}

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -364,7 +364,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			var tags = $('.tags.` + name + `');
 			$('.chips.` + name + `').material_chip({
 				data: [` + strings.Join(initial, ",") + `],
-				secondaryPlaceholder: '+ '` + name + `
+				secondaryPlaceholder: '+` + name + `'
 			});		
 
 			// handle events specific to tags

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -353,7 +353,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	i := 0
 	for _, tag := range tags {
 		tagName := tagNameFromStructFieldMulti(fieldName, i, p)
-		html += `<input type="hidden" class="tag-` + tag + `" name=` + tagName + ` value="` + tag + `"/>`
+		html += `<input type="hidden" class="tag ` + tag + `" name=` + tagName + ` value="` + tag + `"/>`
 		initial = append(initial, `{tag: '`+tag+`'}`)
 		i++
 	}

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -203,3 +203,7 @@ li:hover .quick-delete-post, li:hover .delete-user {
     -o-transform: translateY(-140%);
     transform: translateY(-140%);
 }
+
+.chips {
+    margin-top: 10px;
+}


### PR DESCRIPTION
This allows CMS users to arbitrarily add 'tags' to their content, given the field name provided. 

```go
editor.Field{
			View: editor.Tags("Category", p, map[string]string{
				"label": "Post Categories",
			}),
		},
```