### PR TITLE
[core] Enable content to be submitted from external clients

### DIFF
--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bosssauce/ponzu/system/admin"
 	"github.com/bosssauce/ponzu/system/api"
+	"github.com/bosssauce/ponzu/system/api/analytics"
 	"github.com/bosssauce/ponzu/system/db"
 	"github.com/bosssauce/ponzu/system/tls"
 )
@@ -169,6 +170,11 @@ func main() {
 
 	case "serve", "s":
 		db.Init()
+		defer db.Close()
+
+		analytics.Init()
+		defer analytics.Close()
+
 		if len(args) > 1 {
 			services := strings.Split(args[1], ",")
 

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -169,7 +169,7 @@ func main() {
 
 	case "serve", "s":
 		db.Init()
-		defer db.Close()
+		// defer db.Close()
 
 		// analytics.Init()
 		// defer analytics.Close()

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bosssauce/ponzu/system/admin"
 	"github.com/bosssauce/ponzu/system/api"
-	"github.com/bosssauce/ponzu/system/api/analytics"
 	"github.com/bosssauce/ponzu/system/db"
 	"github.com/bosssauce/ponzu/system/tls"
 )
@@ -172,8 +171,8 @@ func main() {
 		db.Init()
 		defer db.Close()
 
-		analytics.Init()
-		defer analytics.Close()
+		// analytics.Init()
+		// defer analytics.Close()
 
 		if len(args) > 1 {
 			services := strings.Split(args[1], ",")

--- a/cmd/ponzu/main.go
+++ b/cmd/ponzu/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bosssauce/ponzu/system/admin"
 	"github.com/bosssauce/ponzu/system/api"
+	"github.com/bosssauce/ponzu/system/api/analytics"
 	"github.com/bosssauce/ponzu/system/db"
 	"github.com/bosssauce/ponzu/system/tls"
 )
@@ -169,10 +170,10 @@ func main() {
 
 	case "serve", "s":
 		db.Init()
-		// defer db.Close()
+		defer db.Close()
 
-		// analytics.Init()
-		// defer analytics.Close()
+		analytics.Init()
+		defer analytics.Close()
 
 		if len(args) > 1 {
 			services := strings.Split(args[1], ",")

--- a/cmd/ponzu/options.go
+++ b/cmd/ponzu/options.go
@@ -75,7 +75,7 @@ type {{ .name }} struct {
 	Title    string ` + "`json:" + `"title"` + "`" + `
 	Content  string ` + "`json:" + `"content"` + "`" + `
 	Author   string ` + "`json:" + `"author"` + "`" + `
-	Photo    string ` + "`json:" + `"picture"` + "`" + `	
+	Photo    string ` + "`json:" + `"photo"` + "`" + `	
 	Category []string ` + "`json:" + `"category"` + "`" + `
 	Theme	 string ` + "`json:" + `"theme"` + "`" + `
 }

--- a/content/post.go
+++ b/content/post.go
@@ -89,7 +89,7 @@ func (p *Post) SetSlug(slug string) { p.Slug = slug }
 // Editor partially implements editor.Editable
 func (p *Post) Editor() *editor.Editor { return &p.editor }
 
-// Accepts accepts or recjects external requests to submit Review submissions
+// Accepts accepts or recjects external requests to submit Post content
 func (p *Post) Accepts() bool {
 	return true
 }

--- a/content/post.go
+++ b/content/post.go
@@ -88,8 +88,3 @@ func (p *Post) SetSlug(slug string) { p.Slug = slug }
 
 // Editor partially implements editor.Editable
 func (p *Post) Editor() *editor.Editor { return &p.editor }
-
-// // Accepts accepts or recjects external requests to submit Post content
-// func (p *Post) Accepts() bool {
-// 	return true
-// }

--- a/content/post.go
+++ b/content/post.go
@@ -89,7 +89,7 @@ func (p *Post) SetSlug(slug string) { p.Slug = slug }
 // Editor partially implements editor.Editable
 func (p *Post) Editor() *editor.Editor { return &p.editor }
 
-// Accepts accepts or recjects external requests to submit Post content
-func (p *Post) Accepts() bool {
-	return true
-}
+// // Accepts accepts or recjects external requests to submit Post content
+// func (p *Post) Accepts() bool {
+// 	return true
+// }

--- a/content/post.go
+++ b/content/post.go
@@ -91,5 +91,5 @@ func (p *Post) Editor() *editor.Editor { return &p.editor }
 
 // Accepts accepts or recjects external requests to submit Review submissions
 func (p *Post) Accepts() bool {
-	return false
+	return true
 }

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -110,9 +110,11 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<button class="right waves-effect waves-light btn red delete-post" type="submit">Delete</button>
 </div>
 
+<hr>
+
 <div class="input-field external post-controls">
-	<div>This post is pending approval. By clicking 'Approve' it will be immediately published.</div> 
 	<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
+	<div>This post is pending approval. By clicking 'Approve' it will be immediately published.</div> 
 </div>
 
 <script>
@@ -122,11 +124,16 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 			approve = form.find('.post-controls.external'),
 			id = form.find('input[name=id]');
 		
-		// hide delete button if this is a new post, or a non-post editor page
+		// hide if this is a new post, or a non-post editor page
 		if (id.val() === '-1' || form.attr('action') !== '/admin/edit') {
 			del.hide();
 			approve.hide();
 		}
+
+		// hide approval if not on a pending content item
+		if (getParam("status") !== "pending") {
+			approve.hide();
+		} 
 
 		del.on('click', function(e) {
 			e.preventDefault();

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -114,7 +114,7 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<div class="col s12 input-field">
 		<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
 	</div>	
-	<div class="approve-details col s12">This post is pending approval. By clicking 'Approve', it will be immediately published.</div> 
+	<div class="approve-details right-align col s12">This post is pending approval. By clicking 'Approve', it will be immediately published.</div> 
 </div>
 
 <script>

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -110,15 +110,22 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<button class="right waves-effect waves-light btn red delete-post" type="submit">Delete</button>
 </div>
 
+<div class="input-field external post-controls">
+	<div>This post is pending approval. By clicking 'Approve' it will be immediately published.</div> 
+	<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
+</div>
+
 <script>
 	$(function() {
 		var form = $('form'),
 			del = form.find('button.delete-post'),
+			approve = form.find('.post-controls.external'),
 			id = form.find('input[name=id]');
 		
 		// hide delete button if this is a new post, or a non-post editor page
 		if (id.val() === '-1' || form.attr('action') !== '/admin/edit') {
 			del.hide();
+			approve.hide();
 		}
 
 		del.on('click', function(e) {
@@ -130,6 +137,15 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 			if (confirm("[Ponzu] Please confirm:\n\nAre you sure you want to delete this post?\nThis cannot be undone.")) {
 				form.submit();
 			}
+		});
+
+		approve.find('button').on('click', function(e) {
+			e.preventDefault();
+			var action = form.attr('action');
+			action = action + '/approve';
+			form.attr('action', action);
+
+			form.submit();
 		});
 	});
 </script>

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -114,7 +114,7 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<div class="col s12 input-field">
 		<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
 	</div>	
-	<div class="approve-details right-align col s12">This post is pending approval. By clicking 'Approve', it will be immediately published.</div> 
+	<label class="approve-details right-align col s12">This content is pending approval. By clicking 'Approve', it will be immediately published.</label> 
 </div>
 
 <script>

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -110,11 +110,9 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<button class="right waves-effect waves-light btn red delete-post" type="submit">Delete</button>
 </div>
 
-<hr>
-
-<div class="input-field external post-controls">
+<div class="row input-field external post-controls">
+	<div class="col s12">This post is pending approval. By clicking 'Approve' it will be immediately published.</div> 
 	<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
-	<div>This post is pending approval. By clicking 'Approve' it will be immediately published.</div> 
 </div>
 
 <script>

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -110,9 +110,11 @@ func Form(post Editable, fields ...Field) ([]byte, error) {
 	<button class="right waves-effect waves-light btn red delete-post" type="submit">Delete</button>
 </div>
 
-<div class="row input-field external post-controls">
-	<div class="col s12">This post is pending approval. By clicking 'Approve' it will be immediately published.</div> 
-	<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
+<div class="row external post-controls">
+	<div class="col s12 input-field">
+		<button class="right waves-effect waves-light btn blue approve-post" type="submit">Approve</button>
+	</div>	
+	<div class="approve-details col s12">This post is pending approval. By clicking 'Approve', it will be immediately published.</div> 
 </div>
 
 <script>

--- a/system/admin/admin.go
+++ b/system/admin/admin.go
@@ -414,7 +414,7 @@ var err405HTML = `
 <div class="card">
 <div class="card-content">
     <div class="card-title"><b>405</b> Error: Method Not Allowed</div>
-    <blockquote>Sorry, the page you requested could not be found.</blockquote>
+    <blockquote>Sorry, the method of your request is not allowed.</blockquote>
 </div>
 </div>
 </div>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -665,35 +665,69 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 	switch order {
 	case "desc", "":
-		// keep natural order of posts slice, as returned from sorted bucket
-		for i := range posts {
-			err := json.Unmarshal(posts[i], &p)
-			if err != nil {
-				log.Println("Error unmarshal json into", t, err, posts[i])
+		if hasExt {
+			// reverse the order of posts slice
+			for i := len(posts) - 1; i >= 0; i-- {
+				err := json.Unmarshal(posts[i], &p)
+				if err != nil {
+					log.Println("Error unmarshal json into", t, err, posts[i])
 
-				post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
-				b.Write([]byte(post))
-				continue
+					post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
+					b.Write([]byte(post))
+					continue
+				}
+
+				post := adminPostListItem(p, t)
+				b.Write(post)
 			}
+		} else {
+			// keep natural order of posts slice, as returned from sorted bucket
+			for i := range posts {
+				err := json.Unmarshal(posts[i], &p)
+				if err != nil {
+					log.Println("Error unmarshal json into", t, err, posts[i])
 
-			post := adminPostListItem(p, t)
-			b.Write(post)
+					post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
+					b.Write([]byte(post))
+					continue
+				}
+
+				post := adminPostListItem(p, t)
+				b.Write(post)
+			}
 		}
 
 	case "asc":
-		// reverse the order of posts slice
-		for i := len(posts) - 1; i >= 0; i-- {
-			err := json.Unmarshal(posts[i], &p)
-			if err != nil {
-				log.Println("Error unmarshal json into", t, err, posts[i])
+		if hasExt {
+			// keep natural order of posts slice, as returned from sorted bucket
+			for i := range posts {
+				err := json.Unmarshal(posts[i], &p)
+				if err != nil {
+					log.Println("Error unmarshal json into", t, err, posts[i])
 
-				post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
-				b.Write([]byte(post))
-				continue
+					post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
+					b.Write([]byte(post))
+					continue
+				}
+
+				post := adminPostListItem(p, t)
+				b.Write(post)
 			}
+		} else {
+			// reverse the order of posts slice
+			for i := len(posts) - 1; i >= 0; i-- {
+				err := json.Unmarshal(posts[i], &p)
+				if err != nil {
+					log.Println("Error unmarshal json into", t, err, posts[i])
 
-			post := adminPostListItem(p, t)
-			b.Write(post)
+					post := `<li class="col s12">Error decoding data. Possible file corruption.</li>`
+					b.Write([]byte(post))
+					continue
+				}
+
+				post := adminPostListItem(p, t)
+				b.Write(post)
+			}
 		}
 	}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -787,7 +787,7 @@ func adminPostListItem(p editor.Editable, t, status string) []byte {
 
 	post := `
 			<li class="col s12">
-				<a href="/admin/edit?type=` + t + `&status=` + status + `&id=` + cid + `">` + p.ContentName() + `</a>
+				<a href="/admin/edit?type=` + t + `&status=` + strings.TrimPrefix(status, "_") + `&id=` + cid + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -831,6 +831,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			}
 
 			if len(data) < 1 || data == nil {
+				fmt.Println(string(data))
 				res.WriteHeader(http.StatusNotFound)
 				errView, err := Error404()
 				if err != nil {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bosssauce/ponzu/management/editor"
 	"github.com/bosssauce/ponzu/management/manager"
 	"github.com/bosssauce/ponzu/system/admin/config"
+	"github.com/bosssauce/ponzu/system/admin/upload"
 	"github.com/bosssauce/ponzu/system/admin/user"
 	"github.com/bosssauce/ponzu/system/api"
 	"github.com/bosssauce/ponzu/system/db"
@@ -869,7 +870,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			req.PostForm.Set("updated", ts)
 		}
 
-		urlPaths, err := StoreFileUploads(req)
+		urlPaths, err := upload.StoreFiles(req)
 		if err != nil {
 			log.Println(err)
 			res.WriteHeader(http.StatusInternalServerError)
@@ -971,7 +972,7 @@ func editUploadHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	urlPaths, err := StoreFileUploads(req)
+	urlPaths, err := upload.StoreFiles(req)
 	if err != nil {
 		log.Println("Couldn't store file uploads.", err)
 		res.WriteHeader(http.StatusInternalServerError)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -563,7 +563,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	var hasExt bool
-	ext, ok := pt.(api.Externalable)
+	_, ok = pt.(api.Externalable)
 	if ok {
 		hasExt = true
 	}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -869,7 +869,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			req.PostForm.Set("updated", ts)
 		}
 
-		urlPaths, err := storeFileUploads(req)
+		urlPaths, err := StoreFileUploads(req)
 		if err != nil {
 			log.Println(err)
 			res.WriteHeader(http.StatusInternalServerError)
@@ -971,7 +971,7 @@ func editUploadHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	urlPaths, err := storeFileUploads(req)
+	urlPaths, err := StoreFileUploads(req)
 	if err != nil {
 		log.Println("Couldn't store file uploads.", err)
 		res.WriteHeader(http.StatusInternalServerError)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -860,7 +860,7 @@ func approvePostHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// Store the content in the bucket t
-	id, err = db.SetContent(t+":-1", req.Form)
+	id, err := db.SetContent(t+":-1", req.Form)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)
 		errView, err := Error500()
@@ -875,7 +875,7 @@ func approvePostHandler(res http.ResponseWriter, req *http.Request) {
 	// redirect to the new approved content's editor
 	redir := req.URL.Scheme + req.URL.Host + strings.TrimSuffix(req.URL.Path, "/approve")
 	redir += fmt.Sprintf("?type=%s&id=%d", t, id)
-	http.Redirect(res, req, http.StatusFound)
+	http.Redirect(res, req, redir, http.StatusFound)
 }
 
 func editHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -677,7 +677,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t)
+				post := adminPostListItem(p, t, "_pending")
 				b.Write(post)
 			}
 		} else {
@@ -692,7 +692,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t)
+				post := adminPostListItem(p, t, "")
 				b.Write(post)
 			}
 		}
@@ -710,7 +710,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t)
+				post := adminPostListItem(p, t, "_pending")
 				b.Write(post)
 			}
 		} else {
@@ -725,7 +725,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t)
+				post := adminPostListItem(p, t, "")
 				b.Write(post)
 			}
 		}
@@ -762,7 +762,8 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 // adminPostListItem is a helper to create the li containing a post.
 // p is the asserted post as an Editable, t is the Type of the post.
-func adminPostListItem(p editor.Editable, t string) []byte {
+// specifier is passed to append a name to a namespace like _pending
+func adminPostListItem(p editor.Editable, t, specifier string) []byte {
 	s, ok := p.(editor.Sortable)
 	if !ok {
 		log.Println("Content type", t, "doesn't implement editor.Sortable")
@@ -780,14 +781,14 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 
 	post := `
 			<li class="col s12">
-				<a href="/admin/edit?type=` + t + `&id=` + cid + `">` + p.ContentName() + `</a>
+				<a href="/admin/edit?type=` + t + specifier + `&id=` + cid + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 
 				<form enctype="multipart/form-data" class="quick-delete-post __ponzu right" action="/admin/edit/delete" method="post">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
-					<input type="hidden" name="type" value="` + t + `" />
+					<input type="hidden" name="type" value="` + t + specifier + `" />
 				</form>
 			</li>`
 
@@ -817,7 +818,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			if status == "pending" {
 				t = t + "_pending"
 			}
-			fmt.Println(t, i, status)
+
 			data, err := db.Content(t + ":" + i)
 			if err != nil {
 				log.Println(err)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -627,30 +627,30 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
                     </form>	
 					</div>`
 	if hasExt {
-		created := q.Get("created")
+		status := q.Get("status")
 
-		q.Set("created", "internal")
-		intURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+		req.Form.Set("status", "public")
+		publicURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
 
-		q.Set("created", "external")
-		extURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+		req.Form.Set("status", "pending")
+		pendingURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
 
-		switch created {
-		case "internal":
+		switch status {
+		case "public", "":
 
 			html += `<div class="row externalable">
-					Created by: 
-					<a class="active" href="` + intURL + `">Internal</a>
+					Status: 
+					<span class="active">Public</span>
 					&nbsp;&vert;&nbsp;
-					<a href="` + extURL + `">External</a>
+					<a href="` + pendingURL + `">Pending</a>
 				</div>`
 
-		case "external":
+		case "pending":
 			html += `<div class="row externalable">
-					Created by: 
-					<a href="` + intURL + `">Internal</a>
+					Status: 
+					<a href="` + publicURL + `">Public</a>
 					&nbsp;&vert;&nbsp;
-					<a class="active" href="` + extURL + `">External</a>
+					<span class="active">Pending</span>					
 				</div>`
 		}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -677,7 +677,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t, "_pending")
+				post := adminPostListItem(p, t, "pending")
 				b.Write(post)
 			}
 		} else {
@@ -710,7 +710,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t, "_pending")
+				post := adminPostListItem(p, t, "pending")
 				b.Write(post)
 			}
 		} else {
@@ -763,7 +763,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 // adminPostListItem is a helper to create the li containing a post.
 // p is the asserted post as an Editable, t is the Type of the post.
 // specifier is passed to append a name to a namespace like _pending
-func adminPostListItem(p editor.Editable, t, specifier string) []byte {
+func adminPostListItem(p editor.Editable, t, status string) []byte {
 	s, ok := p.(editor.Sortable)
 	if !ok {
 		log.Println("Content type", t, "doesn't implement editor.Sortable")
@@ -781,14 +781,14 @@ func adminPostListItem(p editor.Editable, t, specifier string) []byte {
 
 	post := `
 			<li class="col s12">
-				<a href="/admin/edit?type=` + t + specifier + `&id=` + cid + `">` + p.ContentName() + `</a>
+				<a href="/admin/edit?type=` + t + `&status=` + status + `&id=` + cid + `">` + p.ContentName() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 
 				<form enctype="multipart/form-data" class="quick-delete-post __ponzu right" action="/admin/edit/delete" method="post">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
-					<input type="hidden" name="type" value="` + t + specifier + `" />
+					<input type="hidden" name="type" value="` + t + `_` + status + `" />
 				</form>
 			</li>`
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -640,7 +640,6 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 		switch status {
 		case "public", "":
-
 			html += `<div class="row externalable">
 					<span class="description">Status:</span> 
 					<span class="active">Public</span>
@@ -649,6 +648,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 				</div>`
 
 		case "pending":
+			// get _pending posts of type t from the db
+			posts = db.ContentAll(t + "_pending")
+
 			html += `<div class="row externalable">
 					<span class="description">Status:</span> 
 					<a href="` + publicURL + `">Public</a>
@@ -656,9 +658,6 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					<span class="active">Pending</span>					
 				</div>`
 		}
-
-		// get _pending posts of type t from the db
-		posts = db.ContentAll(t + "_pending")
 
 	}
 	html += `<ul class="posts row">`

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1009,6 +1009,12 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// catch specifier suffix from delete form value
+	if strings.Contains(t, "_") {
+		spec := strings.Split(t, "_")
+		t = spec[0]
+	}
+
 	redir := strings.TrimSuffix(req.URL.Scheme+req.URL.Host+req.URL.Path, "/edit/delete")
 	redir = redir + "/posts?type=" + t
 	http.Redirect(res, req, redir, http.StatusFound)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -629,14 +629,14 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	if hasExt {
 		status := q.Get("status")
 		if status == "" {
-			req.Form.Add("status", "public")
+			q.Add("status", "public")
 		}
 
-		req.Form.Set("status", "public")
-		publicURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+		q.Set("status", "public")
+		publicURL := req.URL.Path + q.Encode()
 
-		req.Form.Set("status", "pending")
-		pendingURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+		q.Set("status", "pending")
+		pendingURL := req.URL.Path + q.Encode()
 
 		switch status {
 		case "public", "":

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -642,7 +642,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		case "public", "":
 
 			html += `<div class="row externalable">
-					Status: 
+					<span class="description">Status:</span> 
 					<span class="active">Public</span>
 					&nbsp;&vert;&nbsp;
 					<a href="` + pendingURL + `">Pending</a>
@@ -650,17 +650,21 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 		case "pending":
 			html += `<div class="row externalable">
-					Status: 
+					<span class="description">Status:</span> 
 					<a href="` + publicURL + `">Public</a>
 					&nbsp;&vert;&nbsp;
 					<span class="active">Pending</span>					
 				</div>`
 		}
 
+		// get _pending posts of type t from the db
+		posts = db.ContentAll(t + "_pending")
+
 	}
 	html += `<ul class="posts row">`
 
-	if order == "desc" || order == "" {
+	switch order {
+	case "desc", "":
 		// keep natural order of posts slice, as returned from sorted bucket
 		for i := range posts {
 			err := json.Unmarshal(posts[i], &p)
@@ -676,7 +680,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 			b.Write(post)
 		}
 
-	} else if order == "asc" {
+	case "asc":
 		// reverse the order of posts slice
 		for i := len(posts) - 1; i >= 0; i-- {
 			err := json.Unmarshal(posts[i], &p)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -19,8 +19,8 @@ import (
 	"github.com/bosssauce/ponzu/system/api"
 	"github.com/bosssauce/ponzu/system/db"
 
+	"github.com/gorilla/schema"
 	"github.com/nilslice/jwt"
-	"github.com/nilslice/ponzu-test/cmd/ponzu/vendor/github.com/gorilla/schema"
 )
 
 func adminHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -534,6 +534,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	order := strings.ToLower(q.Get("order"))
+	status := q.Get("status")
 
 	posts := db.ContentAll(t + "_sorted")
 	b := &bytes.Buffer{}
@@ -628,7 +629,6 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
                     </form>	
 					</div>`
 	if hasExt {
-		status := q.Get("status")
 		if status == "" {
 			q.Add("status", "public")
 		}
@@ -677,7 +677,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t, "pending")
+				post := adminPostListItem(p, t, status)
 				b.Write(post)
 			}
 		} else {
@@ -692,7 +692,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t, "")
+				post := adminPostListItem(p, t, status)
 				b.Write(post)
 			}
 		}
@@ -710,7 +710,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t, "pending")
+				post := adminPostListItem(p, t, status)
 				b.Write(post)
 			}
 		} else {
@@ -725,7 +725,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					continue
 				}
 
-				post := adminPostListItem(p, t, "")
+				post := adminPostListItem(p, t, status)
 				b.Write(post)
 			}
 		}
@@ -779,6 +779,12 @@ func adminPostListItem(p editor.Editable, t, status string) []byte {
 
 	cid := fmt.Sprintf("%d", p.ContentID())
 
+	if status == "public" {
+		status = ""
+	} else {
+		status = "_" + status
+	}
+
 	post := `
 			<li class="col s12">
 				<a href="/admin/edit?type=` + t + `&status=` + status + `&id=` + cid + `">` + p.ContentName() + `</a>
@@ -788,7 +794,7 @@ func adminPostListItem(p editor.Editable, t, status string) []byte {
 				<form enctype="multipart/form-data" class="quick-delete-post __ponzu right" action="/admin/edit/delete" method="post">
 					<span>Delete</span>
 					<input type="hidden" name="id" value="` + cid + `" />
-					<input type="hidden" name="type" value="` + t + `_` + status + `" />
+					<input type="hidden" name="type" value="` + t + status + `" />
 				</form>
 			</li>`
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -633,10 +633,10 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 		q.Set("status", "public")
-		publicURL := req.URL.Path + q.Encode()
+		publicURL := req.URL.Path + "?" + q.Encode()
 
 		q.Set("status", "pending")
-		pendingURL := req.URL.Path + q.Encode()
+		pendingURL := req.URL.Path + "?" + q.Encode()
 
 		switch status {
 		case "public", "":

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -804,6 +804,8 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 		q := req.URL.Query()
 		i := q.Get("id")
 		t := q.Get("type")
+		status := q.Get("status")
+
 		contentType, ok := content.Types[t]
 		if !ok {
 			fmt.Fprintf(res, content.ErrTypeNotRegistered, t)
@@ -812,6 +814,9 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 		post := contentType()
 
 		if i != "" {
+			if status == "pending" {
+				t = t + "_pending"
+			}
 			data, err := db.Content(t + ":" + i)
 			if err != nil {
 				log.Println(err)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -585,21 +585,6 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 							</div>	
 							<script>
 								$(function() {
-									var getParam = function(param) {
-										var qs = window.location.search.substring(1);
-										var qp = qs.split('&');
-										var t = '';
-
-										for (var i = 0; i < qp.length; i++) {
-											var p = qp[i].split('=')
-											if (p[0] === param) {
-												t = p[1];	
-											}
-										}
-
-										return t;
-									}
-
 									var sort = $('select.__ponzu.sort-order');
 
 									sort.on('change', function() {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1070,7 +1070,7 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		post := adminPostListItem(p, t)
+		post := adminPostListItem(p, t, "")
 		b.Write([]byte(post))
 	}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -629,7 +629,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	if hasExt {
 		status := q.Get("status")
 		if status == "" {
-			req.Form.Add("status", "")
+			req.Form.Add("status", "public")
 		}
 
 		req.Form.Set("status", "public")

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -628,6 +628,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					</div>`
 	if hasExt {
 		status := q.Get("status")
+		if status == "" {
+			req.Form.Add("status", "")
+		}
 
 		req.Form.Set("status", "public")
 		publicURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -628,31 +628,32 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					</div>`
 	if hasExt {
 		created := q.Get("created")
+
+		q.Set("created", "internal")
+		intURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+
+		q.Set("created", "external")
+		extURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+
 		switch created {
-			q.Set("created", "internal")
-			intURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
+		case "internal":
 
-			q.Set("created", "external")		
-			extURL := strings.TrimPrefix(req.URL.String(), req.URL.Scheme+req.URL.Host)
-
-			case "internal":
-			
 			html += `<div class="row">
 					Created by: 
-					<a class="active" href="`+ intURL  +`">Internal</a>
+					<a class="active" href="` + intURL + `">Internal</a>
 					&nbsp;&vert;&nbsp;
-					<a href="`+ extURL  +`">External</a>
+					<a href="` + extURL + `">External</a>
 				</div>`
 
-			case "external":
+		case "external":
 			html += `<div class="row">
 					Created by: 
-					<a href="`+ intURL  +`">Internal</a>
+					<a href="` + intURL + `">Internal</a>
 					&nbsp;&vert;&nbsp;
-					<a class="active" href="`+ extURL  +`">External</a>
+					<a class="active" href="` + extURL + `">External</a>
 				</div>`
 		}
-		
+
 	}
 	html += `<ul class="posts row">`
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -817,6 +817,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			if status == "pending" {
 				t = t + "_pending"
 			}
+			fmt.Println(t, i, status)
 			data, err := db.Content(t + ":" + i)
 			if err != nil {
 				log.Println(err)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -638,7 +638,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		switch created {
 		case "internal":
 
-			html += `<div class="row">
+			html += `<div class="row externalable">
 					Created by: 
 					<a class="active" href="` + intURL + `">Internal</a>
 					&nbsp;&vert;&nbsp;
@@ -646,7 +646,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 				</div>`
 
 		case "external":
-			html += `<div class="row">
+			html += `<div class="row externalable">
 					Created by: 
 					<a href="` + intURL + `">Internal</a>
 					&nbsp;&vert;&nbsp;
@@ -751,6 +751,10 @@ func adminPostListItem(p editor.Editable, t string) []byte {
 			</li>`
 
 	return []byte(post)
+}
+
+func approvePostHandler(res http.ResponseWriter, req *http.Request) {
+
 }
 
 func editHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -24,11 +24,11 @@ func Run() {
 	http.HandleFunc("/admin/configure/users/delete", user.Auth(configUsersDeleteHandler))
 
 	http.HandleFunc("/admin/posts", user.Auth(postsHandler))
-	http.HandleFunc("/admin/posts/approve", user.Auth(approvePostHandler))
 	http.HandleFunc("/admin/posts/search", user.Auth(searchHandler))
 
 	http.HandleFunc("/admin/edit", user.Auth(editHandler))
 	http.HandleFunc("/admin/edit/delete", user.Auth(deleteHandler))
+	http.HandleFunc("/admin/edit/approve", user.Auth(approvePostHandler))
 	http.HandleFunc("/admin/edit/upload", user.Auth(editUploadHandler))
 
 	pwd, err := os.Getwd()

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -24,6 +24,7 @@ func Run() {
 	http.HandleFunc("/admin/configure/users/delete", user.Auth(configUsersDeleteHandler))
 
 	http.HandleFunc("/admin/posts", user.Auth(postsHandler))
+	http.HandleFunc("/admin/posts/approve", user.Auth(approvePostHandler))
 	http.HandleFunc("/admin/posts/search", user.Auth(searchHandler))
 
 	http.HandleFunc("/admin/edit", user.Auth(editHandler))

--- a/system/admin/static/common/js/util.js
+++ b/system/admin/static/common/js/util.js
@@ -68,3 +68,19 @@ function getPartialDate(unix) {
 
     return d;
 }
+
+// Returns a part of the window URL 'search' string
+function getParam(param) {
+    var qs = window.location.search.substring(1);
+    var qp = qs.split('&');
+    var t = '';
+
+    for (var i = 0; i < qp.length; i++) {
+        var p = qp[i].split('=')
+        if (p[0] === param) {
+            t = p[1];	
+        }
+    }
+
+    return t;
+}

--- a/system/admin/static/dashboard/css/admin.css
+++ b/system/admin/static/dashboard/css/admin.css
@@ -207,3 +207,13 @@ li:hover .quick-delete-post, li:hover .delete-user {
 .chips {
     margin-top: 10px;
 }
+
+.external.post-controls .col.input-field {
+    margin-top: 40px;
+    padding: 0;
+}
+
+.approve-details {
+    text-align: right;
+    padding: 10px 0 !important;
+}

--- a/system/admin/upload.go
+++ b/system/admin/upload.go
@@ -10,7 +10,8 @@ import (
 	"time"
 )
 
-func storeFileUploads(req *http.Request) (map[string]string, error) {
+// StoreFileUploads stores file uploads at paths like /YYYY/MM/filename.ext
+func StoreFileUploads(req *http.Request) (map[string]string, error) {
 	err := req.ParseMultipartForm(1024 * 1024 * 4) // maxMemory 4MB
 	if err != nil {
 		return nil, fmt.Errorf("%s", err)

--- a/system/admin/upload/upload.go
+++ b/system/admin/upload/upload.go
@@ -1,4 +1,4 @@
-package admin
+package upload
 
 import (
 	"fmt"
@@ -10,8 +10,8 @@ import (
 	"time"
 )
 
-// StoreFileUploads stores file uploads at paths like /YYYY/MM/filename.ext
-func StoreFileUploads(req *http.Request) (map[string]string, error) {
+// StoreFiles stores file uploads at paths like /YYYY/MM/filename.ext
+func StoreFiles(req *http.Request) (map[string]string, error) {
 	err := req.ParseMultipartForm(1024 * 1024 * 4) // maxMemory 4MB
 	if err != nil {
 		return nil, fmt.Errorf("%s", err)

--- a/system/api/analytics/analytics.go
+++ b/system/api/analytics/analytics.go
@@ -1,0 +1,97 @@
+// Package analytics provides the methods to run an analytics reporting system
+// for API requests which may be useful to users for measuring access and
+// possibly identifying bad actors abusing requests.
+package analytics
+
+import (
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+type apiRequest struct {
+	URL        string `json:"url"`
+	Method     string `json:"http_method"`
+	RemoteAddr string `json:"ip_address"`
+	Timestamp  int64  `json:"timestamp"`
+	External   bool   `json:"external"`
+}
+
+var (
+	store      *bolt.DB
+	recordChan chan apiRequest
+)
+
+// Record queues an apiRequest for metrics
+func Record(req *http.Request) {
+	external := strings.Contains(req.URL.Path, "/external/")
+
+	r := apiRequest{
+		URL:        req.URL.String(),
+		Method:     req.Method,
+		RemoteAddr: req.RemoteAddr,
+		Timestamp:  time.Now().Unix() * 1000,
+		External:   external,
+	}
+
+	// put r on buffered recordChan to take advantage of batch insertion in DB
+	recordChan <- r
+
+}
+
+// Close exports the abillity to close our db file. Should be called with defer
+// after call to Init() from the same place.
+func Close() {
+	err := store.Close()
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// Init creates a db connection, should run an initial prune of old data, and
+// sets up the queue/batching channel
+func Init() {
+	store, err := bolt.Open("analytics.db", 0666, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	recordChan = make(chan apiRequest, 1024*128)
+
+	go serve()
+
+	err = store.Update(func(tx *bolt.Tx) error {
+
+		return nil
+	})
+}
+
+func serve() {
+	// make timer to notify select to batch request insert from recordChan
+	// interval: 1 minute
+	apiRequestTimer := time.NewTicker(time.Minute * 1)
+
+	// make timer to notify select to remove old analytics
+	// interval: 2 weeks
+	// TODO: enable analytics backup service to cloud
+	pruneDBTimer := time.NewTicker(time.Hour * 24 * 14)
+
+	for {
+		select {
+		case <-apiRequestTimer.C:
+			var reqs []apiRequest
+			batchSize := len(recordChan)
+
+			for i := 0; i < batchSize; i++ {
+				reqs = append(reqs, <-recordChan)
+			}
+
+		case <-pruneDBTimer.C:
+
+		default:
+		}
+	}
+}

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -4,7 +4,6 @@
 package analytics
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -55,12 +54,11 @@ func Close() {
 // Init creates a db connection, should run an initial prune of old data, and
 // sets up the queue/batching channel
 func Init() {
-	store, err := bolt.Open("analytics.db", 0666, nil)
+	var err error
+	store, err = bolt.Open("analytics.db", 0666, nil)
 	if err != nil {
 		log.Fatalln(err)
 	}
-
-	fmt.Println("analytics", store)
 
 	recordChan = make(chan apiRequest, 1024*128)
 

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -4,6 +4,7 @@
 package analytics
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -59,6 +60,8 @@ func Init() {
 		log.Fatalln(err)
 	}
 
+	fmt.Println("analytics", store)
+
 	recordChan = make(chan apiRequest, 1024*128)
 
 	go serve()
@@ -67,6 +70,9 @@ func Init() {
 
 		return nil
 	})
+	if err != nil {
+		log.Fatalln(err)
+	}
 }
 
 func serve() {

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -59,7 +59,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	if ext.Accepts() {
-		_, err := db.SetContent(t+"_external"+":-1", req.Form)
+		err := db.SetPendingContent(t+"_pending", req.Form)
 		if err != nil {
 			log.Println("[External] error:", err)
 			res.WriteHeader(http.StatusInternalServerError)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -44,6 +44,11 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	if ext.Accept() {
-		db.SetContent(t+"_external"+":-1", req.Form)
+		_, err := db.SetContent(t+"_external"+":-1", req.Form)
+		if err != nil {
+			log.Println("[External]", err)
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -99,7 +99,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 			req.PostForm.Del(discardKey)
 		}
 
-		_, err = db.SetContent(t+":-1", req.PostForm)
+		_, err = db.SetContent(t+"_pending:-1", req.PostForm)
 		if err != nil {
 			log.Println("[External] error:", err)
 			res.WriteHeader(http.StatusInternalServerError)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -99,7 +99,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 			req.PostForm.Del(discardKey)
 		}
 
-		_, err = db.SetPendingContent(t, req.PostForm)
+		_, err = db.SetContent(t+":-1", req.PostForm)
 		if err != nil {
 			log.Println("[External] error:", err)
 			res.WriteHeader(http.StatusInternalServerError)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -66,7 +66,6 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 		ts := fmt.Sprintf("%d", time.Now().Unix()*1000)
 		req.PostForm.Set("timestamp", ts)
 		req.PostForm.Set("updated", ts)
-		req.PostForm.Set("id", ts)
 
 		urlPaths, err := upload.StoreFiles(req)
 		if err != nil {
@@ -100,7 +99,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 			req.PostForm.Del(discardKey)
 		}
 
-		err = db.SetPendingContent(t+"_pending", req.PostForm)
+		_, err = db.SetPendingContent(t, req.PostForm)
 		if err != nil {
 			log.Println("[External] error:", err)
 			res.WriteHeader(http.StatusInternalServerError)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -14,6 +14,7 @@ type Externalable interface {
 }
 
 func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
+	log.Println("External request")
 	if req.Method != http.MethodPost {
 		res.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/bosssauce/ponzu/content"
-	"github.com/bosssauce/ponzu/system/admin"
+	"github.com/bosssauce/ponzu/system/admin/upload"
 	"github.com/bosssauce/ponzu/system/db"
 )
 
@@ -68,7 +68,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 		req.PostForm.Set("updated", ts)
 		req.PostForm.Set("id", ts)
 
-		urlPaths, err := admin.storeFileUploads(req)
+		urlPaths, err := upload.StoreFiles(req)
 		if err != nil {
 			log.Println(err)
 			res.WriteHeader(http.StatusInternalServerError)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -10,6 +10,7 @@ import (
 
 // Externalable accepts or rejects external POST requests to /external/posts?type=Review
 type Externalable interface {
+	// Accepts determines whether a type will allow external submissions
 	Accepts() bool
 }
 
@@ -21,7 +22,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 
 	err := req.ParseMultipartForm(1024 * 1024 * 4) // maxMemory 4MB
 	if err != nil {
-		log.Println("[External]", err)
+		log.Println("[External] error:", err)
 		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -34,7 +35,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 
 	p, found := content.Types[t]
 	if !found {
-		log.Println("[External] Attempt to submit content", t, "by", req.RemoteAddr)
+		log.Println("[External] attempt to submit unknown type:", t, "from:", req.RemoteAddr)
 		res.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -43,15 +44,15 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 
 	ext, ok := post.(Externalable)
 	if !ok {
-		log.Println("[External]", err)
-		res.WriteHeader(http.StatusInternalServerError)
+		log.Println("[External] rejected non-externalable type:", t, "from:", req.RemoteAddr)
+		res.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	if ext.Accepts() {
 		_, err := db.SetContent(t+"_external"+":-1", req.Form)
 		if err != nil {
-			log.Println("[External]", err)
+			log.Println("[External] error:", err)
 			res.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -26,6 +26,8 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	log.Println("type:", t)
+	log.Println("of:", content.Types)
 	p, found := content.Types[t]
 	if !found {
 		log.Println("Attempt to submit content", t, "by", req.RemoteAddr)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -8,10 +8,19 @@ import (
 	"github.com/bosssauce/ponzu/system/db"
 )
 
-// Externalable accepts or rejects external POST requests to /external/posts?type=Review
+// Externalable accepts or rejects external POST requests to endpoints such as:
+// /external/posts?type=Review
 type Externalable interface {
 	// Accepts determines whether a type will allow external submissions
 	Accepts() bool
+}
+
+// Mergeable allows external post content to be approved and published through
+// the public-facing API
+type Mergeable interface {
+	// Approve copies an external post to the internal collection and triggers
+	// a re-sort of its content type posts
+	Approve() error
 }
 
 func externalPostsHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -10,7 +10,7 @@ import (
 
 // Externalable accepts or rejects external POST requests to /external/posts?type=Review
 type Externalable interface {
-	Accept() bool
+	Accepts() bool
 }
 
 func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
@@ -43,7 +43,7 @@ func externalPostsHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if ext.Accept() {
+	if ext.Accepts() {
 		_, err := db.SetContent(t+"_external"+":-1", req.Form)
 		if err != nil {
 			log.Println("[External]", err)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -24,7 +24,7 @@ type Externalable interface {
 type Mergeable interface {
 	// Approve copies an external post to the internal collection and triggers
 	// a re-sort of its content type posts
-	Approve() error
+	Approve(req *http.Request) error
 }
 
 func externalPostsHandler(res http.ResponseWriter, req *http.Request) {

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/bosssauce/ponzu/content"
+	"github.com/bosssauce/ponzu/system/api/analytics"
 	"github.com/bosssauce/ponzu/system/db"
 )
 
@@ -210,9 +211,6 @@ func SendJSON(res http.ResponseWriter, j map[string]interface{}) {
 	sendData(res, data, 200)
 }
 
-// ResponseFunc ...
-type ResponseFunc func(http.ResponseWriter, *http.Request)
-
 // CORS wraps a HandleFunc to response to OPTIONS requests properly
 func CORS(next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -220,6 +218,15 @@ func CORS(next http.HandlerFunc) http.HandlerFunc {
 			SendPreflight(res)
 			return
 		}
+
+		next.ServeHTTP(res, req)
+	})
+}
+
+// Record wraps a HandleFunc to record API requests for analytical purposes
+func Record(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		go analytics.Record(req)
 
 		next.ServeHTTP(res, req)
 	})

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -120,6 +120,7 @@ func insert(ns string, data url.Values) (int, error) {
 
 func postToJSON(ns string, data url.Values) ([]byte, error) {
 	// find the content type and decode values into it
+	ns = strings.TrimSuffix(ns, "_external")
 	t, ok := content.Types[ns]
 	if !ok {
 		return nil, fmt.Errorf(content.ErrTypeNotRegistered, ns)

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -24,6 +24,8 @@ func SetContent(target string, data url.Values) (int, error) {
 	t := strings.Split(target, ":")
 	ns, id := t[0], t[1]
 
+	log.Println(ns, id, data)
+
 	// check if content id == -1 (indicating new post).
 	// if so, run an insert which will assign the next auto incremented int.
 	// this is done because boltdb begins its bucket auto increment value at 0,

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -72,6 +72,7 @@ func update(ns, id string, data url.Values) (int, error) {
 
 func insert(ns string, data url.Values) (int, error) {
 	var effectedID int
+	log.Println(ns)
 	err := store.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(ns))
 		if err != nil {

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -202,8 +202,8 @@ func ContentAll(namespace string) [][]byte {
 	store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(namespace))
 
-		len := b.Stats().KeyN
-		posts = make([][]byte, 0, len)
+		numKeys := b.Stats().KeyN
+		posts = make([][]byte, 0, numKeys)
 
 		b.ForEach(func(k, v []byte) error {
 			posts = append(posts, v)
@@ -224,7 +224,7 @@ func SortContent(namespace string) {
 	all := ContentAll(namespace)
 
 	var posts sortablePosts
-	// decode each (json) into Editable
+	// decode each (json) into type to then sort
 	for i := range all {
 		j := all[i]
 		post := content.Types[namespace]()
@@ -243,11 +243,6 @@ func SortContent(namespace string) {
 
 	// store in <namespace>_sorted bucket, first delete existing
 	err := store.Update(func(tx *bolt.Tx) error {
-		err := tx.DeleteBucket([]byte(namespace + "_sorted"))
-		if err != nil {
-			return err
-		}
-
 		b, err := tx.CreateBucket([]byte(namespace + "_sorted"))
 		if err != nil {
 			err := tx.Rollback()

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -199,6 +199,10 @@ func ContentAll(namespace string) [][]byte {
 	store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(namespace))
 
+		if b == nil {
+			return nil
+		}
+
 		numKeys := b.Stats().KeyN
 		posts = make([][]byte, 0, numKeys)
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -42,7 +42,7 @@ func update(ns, id string, data url.Values) (int, error) {
 	if strings.Contains(ns, "_") {
 		spec := strings.Split(ns, "_")
 		ns = spec[0]
-		specifier = spec[1]
+		specifier = "_" + spec[1]
 	}
 
 	cid, err := strconv.Atoi(id)
@@ -51,7 +51,7 @@ func update(ns, id string, data url.Values) (int, error) {
 	}
 
 	err = store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte(ns + "_" + specifier))
+		b, err := tx.CreateBucketIfNotExists([]byte(ns + specifier))
 		if err != nil {
 			return err
 		}
@@ -85,11 +85,11 @@ func insert(ns string, data url.Values) (int, error) {
 	if strings.Contains(ns, "_") {
 		spec := strings.Split(ns, "_")
 		ns = spec[0]
-		specifier = spec[1]
+		specifier = "_" + spec[1]
 	}
 
 	err := store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte(ns + "_" + specifier))
+		b, err := tx.CreateBucketIfNotExists([]byte(ns + specifier))
 		if err != nil {
 			return err
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -74,7 +74,7 @@ func update(ns, id string, data url.Values) (int, error) {
 
 func insert(ns string, data url.Values) (int, error) {
 	var effectedID int
-	log.Println(ns)
+
 	err := store.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(ns))
 		if err != nil {

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -263,11 +263,6 @@ func SortContent(namespace string) {
 			cid := fmt.Sprintf("%d:%d", i, posts[i].Time())
 			err = b.Put([]byte(cid), j)
 			if err != nil {
-				err := tx.Rollback()
-				if err != nil {
-					return err
-				}
-
 				return err
 			}
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -51,7 +51,7 @@ func update(ns, id string, data url.Values) (int, error) {
 	}
 
 	err = store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte(ns + specifier))
+		b, err := tx.CreateBucketIfNotExists([]byte(ns + "_" + specifier))
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func insert(ns string, data url.Values) (int, error) {
 	}
 
 	err := store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte(ns + specifier))
+		b, err := tx.CreateBucketIfNotExists([]byte(ns + "_" + specifier))
 		if err != nil {
 			return err
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -243,7 +243,7 @@ func SortContent(namespace string) {
 
 	// store in <namespace>_sorted bucket, first delete existing
 	err := store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte(namespace + "_sorted"))
+		b, err := tx.CreateBucketIfNotExists([]byte(namespace + "_sorted"))
 		if err != nil {
 			return err
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -140,7 +140,6 @@ func DeleteContent(target string) error {
 		tx.Bucket([]byte(ns)).Delete([]byte(id))
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}
@@ -207,6 +206,11 @@ func ContentAll(namespace string) [][]byte {
 // in descending order, from most recent to least recent
 // Should be called from a goroutine after SetContent is successful
 func SortContent(namespace string) {
+	// only sort main content types i.e. Post
+	if strings.Contains(namespace, "_") {
+		return
+	}
+
 	all := ContentAll(namespace)
 
 	var posts sortablePosts

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -229,7 +229,13 @@ func SortContent(namespace string) {
 
 	// store in <namespace>_sorted bucket, first delete existing
 	err := store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte(namespace + "_sorted"))
+		bname := []byte(namespace + "_sorted")
+		err := tx.DeleteBucket(bname)
+		if err != nil {
+			return err
+		}
+
+		b, err := tx.CreateBucketIfNotExists(bname)
 		if err != nil {
 			return err
 		}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -92,7 +92,7 @@ func insert(ns string, data url.Values) (int, error) {
 		if err != nil {
 			return err
 		}
-		data.Add("id", cid)
+		data.Set("id", cid)
 
 		j, err := postToJSON(ns, data)
 		if err != nil {

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -245,11 +245,6 @@ func SortContent(namespace string) {
 	err := store.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte(namespace + "_sorted"))
 		if err != nil {
-			err := tx.Rollback()
-			if err != nil {
-				return err
-			}
-
 			return err
 		}
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -24,8 +24,6 @@ func SetContent(target string, data url.Values) (int, error) {
 	t := strings.Split(target, ":")
 	ns, id := t[0], t[1]
 
-	log.Println(ns, id, data)
-
 	// check if content id == -1 (indicating new post).
 	// if so, run an insert which will assign the next auto incremented int.
 	// this is done because boltdb begins its bucket auto increment value at 0,

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -79,11 +79,13 @@ func Init() {
 	}
 
 	// sort all content into type_sorted buckets
-	go func() {
-		for t := range content.Types {
-			SortContent(t)
-		}
-	}()
+	if SystemInitComplete() {
+		go func() {
+			for t := range content.Types {
+				SortContent(t)
+			}
+		}()
+	}
 
 }
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -79,13 +79,13 @@ func Init() {
 	}
 
 	// sort all content into type_sorted buckets
-	if SystemInitComplete() {
-		go func() {
-			for t := range content.Types {
-				SortContent(t)
-			}
-		}()
-	}
+	// if SystemInitComplete() {
+	// 	go func() {
+	// 		for t := range content.Types {
+	// 			SortContent(t)
+	// 		}
+	// 	}()
+	// }
 
 }
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/bosssauce/ponzu/content"
@@ -28,6 +29,8 @@ func Init() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	fmt.Println("system", store)
 
 	err = store.Update(func(tx *bolt.Tx) error {
 		// initialize db with all content type buckets & sorted bucket for type
@@ -78,14 +81,11 @@ func Init() {
 		log.Fatalln("Coudn't initialize db with buckets.", err)
 	}
 
-	// sort all content into type_sorted buckets
-	// if SystemInitComplete() {
-	// 	go func() {
-	// 		for t := range content.Types {
-	// 			SortContent(t)
-	// 		}
-	// 	}()
-	// }
+	go func() {
+		for t := range content.Types {
+			SortContent(t)
+		}
+	}()
 
 }
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -13,12 +13,20 @@ import (
 
 var store *bolt.DB
 
+// Close exports the abillity to close our db file. Should be called with defer
+// after call to Init() from the same place.
+func Close() {
+	err := store.Close()
+	if err != nil {
+		log.Println(err)
+	}
+}
+
 // Init creates a db connection, initializes db with required info, sets secrets
 func Init() {
-	var err error
-	store, err = bolt.Open("store.db", 0666, nil)
+	store, err := bolt.Open("system.db", 0666, nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	err = store.Update(func(tx *bolt.Tx) error {
@@ -67,7 +75,7 @@ func Init() {
 		return nil
 	})
 	if err != nil {
-		log.Fatal("Coudn't initialize db with buckets.", err)
+		log.Fatalln("Coudn't initialize db with buckets.", err)
 	}
 
 	// sort all content into type_sorted buckets
@@ -99,7 +107,7 @@ func SystemInitComplete() bool {
 	})
 	if err != nil {
 		complete = false
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	return complete

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 
 	"github.com/bosssauce/ponzu/content"
@@ -25,12 +24,11 @@ func Close() {
 
 // Init creates a db connection, initializes db with required info, sets secrets
 func Init() {
-	store, err := bolt.Open("system.db", 0666, nil)
+	var err error
+	store, err = bolt.Open("system.db", 0666, nil)
 	if err != nil {
 		log.Fatalln(err)
 	}
-
-	fmt.Println("system", store)
 
 	err = store.Update(func(tx *bolt.Tx) error {
 		// initialize db with all content type buckets & sorted bucket for type

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -79,11 +79,11 @@ func Init() {
 		log.Fatalln("Coudn't initialize db with buckets.", err)
 	}
 
-	go func(types map[string]func() interface{}) {
-		for t := range types {
+	go func() {
+		for t := range content.Types {
 			SortContent(t)
 		}
-	}(content.Types)
+	}()
 
 }
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -81,11 +81,11 @@ func Init() {
 		log.Fatalln("Coudn't initialize db with buckets.", err)
 	}
 
-	go func() {
-		for t := range content.Types {
+	go func(types map[string]func() interface{}) {
+		for t := range types {
 			SortContent(t)
 		}
-	}()
+	}(content.Types)
 
 }
 


### PR DESCRIPTION
I'm excited about this feature, having built numerous apps to handle user-submitted content which would then be re-displayed publicly. This PR is mostly about the two new interfaces and their use for externally submitted content, and the admin's ability to merge that content into the internal feed.

### Externalable
```go
// Externalable accepts or rejects external POST requests to endpoints such as:
// /external/posts?type=Review
type Externalable interface {
	// Accepts determines whether a type will allow external submissions
	Accepts() bool
}
```

### Mergeable
```go
// Mergeable allows external post content to be approved and published through
// the public-facing API
type Mergeable interface {
	// Approve copies an external post to the internal collection and triggers
	// a re-sort of its content type posts
	Approve(req *http.Request) error
}
```

Now, for any developer-added or generated content type, it only requires an additional method `Accepts() bool` to allow for external clients to send data, and another `Approve(req *http.Request) error` to approve that submitted content and merge it into the main content bucket.

Note: there is also some code in here which has not been fully implemented.. anything in the `analytics` package should be ignored. If you're interested, message me and I'll share the details.