### PR TITLE
[core] better error logging for interface type assertions

### DIFF
--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -825,6 +825,7 @@ func approvePostHandler(res http.ResponseWriter, req *http.Request) {
 	// check if we have a Mergeable
 	m, ok := post.(api.Mergeable)
 	if !ok {
+		log.Println("Contant type", t, "must implement api.Mergable before it can bee approved.")
 		res.WriteHeader(http.StatusBadRequest)
 		errView, err := Error400()
 		if err != nil {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -825,7 +825,7 @@ func approvePostHandler(res http.ResponseWriter, req *http.Request) {
 	// check if we have a Mergeable
 	m, ok := post.(api.Mergeable)
 	if !ok {
-		log.Println("Contant type", t, "must implement api.Mergable before it can bee approved.")
+		log.Println("Content type", t, "must implement api.Mergable before it can bee approved.")
 		res.WriteHeader(http.StatusBadRequest)
 		errView, err := Error400()
 		if err != nil {


### PR DESCRIPTION
Will need to do a more thorough scan of all type assertions to log this message out to the programmer/user so they know an action couldn't be completed due to implementation failure of necessary interface(s).