### PR TITLE
[core] Added account recovery process and content pagination in admin UI

### DIFF
--- a/cmd/ponzu/contentType.tmpl
+++ b/cmd/ponzu/contentType.tmpl
@@ -41,10 +41,6 @@ func init() {
 	Types["{{ .Name }}"] = func() interface{} { return new({{ .Name }}) }
 }
 
-// ContentName is required to set the display name for a piece of content in the editor
-// Partially implements editor.Editable
-func ({{ .Initial }} *{{ .Name }}) ContentName() string { return fmt.Sprintf("{{ .Name }} - ID: %s", {{ .Initial }}.UniqueID()) }
-
 // Editor is a buffer of bytes for the Form function to write input views
 // partially implements editor.Editable
 func ({{ .Initial }} *{{ .Name }}) Editor() *editor.Editor { return &{{ .Initial }}.editor }

--- a/cmd/ponzu/vendor/github.com/nilslice/email/README.md
+++ b/cmd/ponzu/vendor/github.com/nilslice/email/README.md
@@ -19,7 +19,7 @@ import (
 func main() {
     msg := email.Message{
         To: "you@server.name", // do not add < > or name in quotes
-        From: "Name <me@server.name>", // ok to format in From field
+        From: "me@server.name", // do not add < > or name in quotes
         Subject: "A simple email",
         Body: "Plain text email body. HTML not yet supported, but send a PR!",
     }

--- a/cmd/ponzu/vendor/github.com/nilslice/email/email.go
+++ b/cmd/ponzu/vendor/github.com/nilslice/email/email.go
@@ -94,7 +94,7 @@ func send(m Message, c *smtp.Client) error {
 	}
 
 	if m.To != "" {
-		_, err = msg.Write([]byte("To: " + m.To + "\r\n"))
+		_, err = msg.Write([]byte("To: " + m.To + " <" + m.To + ">\r\n"))
 		if err != nil {
 			return err
 		}

--- a/cmd/ponzu/vendor/github.com/nilslice/email/email.go
+++ b/cmd/ponzu/vendor/github.com/nilslice/email/email.go
@@ -110,5 +110,10 @@ func send(m Message, c *smtp.Client) error {
 		return err
 	}
 
+	err = c.Quit()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cmd/ponzu/vendor/github.com/nilslice/email/email.go
+++ b/cmd/ponzu/vendor/github.com/nilslice/email/email.go
@@ -87,7 +87,7 @@ func send(m Message, c *smtp.Client) error {
 	}
 
 	if m.From != "" {
-		_, err = msg.Write([]byte("From: " + m.From + "\r\n"))
+		_, err = msg.Write([]byte("From: " + m.From + " <" + m.From + ">\r\n"))
 		if err != nil {
 			return err
 		}

--- a/cmd/ponzu/vendor/github.com/nilslice/email/email.go
+++ b/cmd/ponzu/vendor/github.com/nilslice/email/email.go
@@ -87,14 +87,14 @@ func send(m Message, c *smtp.Client) error {
 	}
 
 	if m.From != "" {
-		_, err = msg.Write([]byte("From: " + m.From + " <" + m.From + ">\r\n"))
+		_, err = msg.Write([]byte("From: <" + m.From + ">\r\n"))
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.To != "" {
-		_, err = msg.Write([]byte("To: " + m.To + " <" + m.To + ">\r\n"))
+		_, err = msg.Write([]byte("To: <" + m.To + ">\r\n"))
 		if err != nil {
 			return err
 		}

--- a/content/item.go
+++ b/content/item.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"fmt"
 	"net/http"
 
 	uuid "github.com/satori/go.uuid"
@@ -22,6 +23,7 @@ type Identifiable interface {
 	ItemID() int
 	SetItemID(int)
 	UniqueID() uuid.UUID
+	String() string
 }
 
 // Hookable provides our user with an easy way to intercept or add functionality
@@ -81,6 +83,12 @@ func (i *Item) SetItemID(id int) {
 // partially implements the Identifiable interface
 func (i Item) UniqueID() uuid.UUID {
 	return i.UUID
+}
+
+// String formats an Item into a printable value
+// partially implements the Identifiable interface
+func (i Item) String() string {
+	return fmt.Sprintf("Item ID: %s", i.UniqueID())
 }
 
 // BeforeSave is a no-op to ensure structs which embed Item implement Hookable

--- a/content/types.go
+++ b/content/types.go
@@ -6,13 +6,13 @@ const (
 There is no type registered for %[1]s
 
 Add this to the file which defines %[1]s{} in the 'content' package:
---------------------------------------------------------------------------+
 
-func init() {			
-	Types["%[1]s"] = func() interface{} { return new(%[1]s) }
-}		
+
+	func init() {			
+		Types["%[1]s"] = func() interface{} { return new(%[1]s) }
+	}		
 				
---------------------------------------------------------------------------+
+
 `
 )
 

--- a/management/editor/editor.go
+++ b/management/editor/editor.go
@@ -9,7 +9,6 @@ import (
 
 // Editable ensures data is editable
 type Editable interface {
-	ContentName() string
 	Editor() *Editor
 	MarshalEditor() ([]byte, error)
 }

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -386,9 +386,11 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
-				var sel = '.__ponzu-tag.'+chip.tag.split(' ').join('.');	
-				console.log(sel);
-				console.log(chips.parent().find(sel));			
+				var sel = '.__ponzu-tag';
+				if (chip.tag.length > 0) {			
+					sel += '.';
+					sel += chip.tag.split(' ').join('.');
+				}
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -341,9 +341,10 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 	// get the saved tags if this is already an existing post
 	values := valueFromStructField(fieldName, p)
-	tags := strings.Split(values, "__ponzu")
-
-	fmt.Println(tags, len(tags))
+	var tags []string
+	if strings.Contains(values, "__ponzu") {
+		tags = strings.Split(values, "__ponzu")
+	}
 
 	html := `
 	<div class="col s12 __ponzu-tags ` + name + `">

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -375,7 +375,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				
 				var input = $('<input>');
 				input.attr({
-					class: 'tag '+chip.tag,
+					class: '__ponzu-tag '+chip.tag,
 					name: '` + name + `.'+String(tags.find('input[type=hidden]').length),
 					value: chip.tag,
 					type: 'hidden'
@@ -386,9 +386,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
-				console.log(chip);
 				var sel = '.__ponzu-tag.' + chip.tag.split(' ').join('.');
-				console.log(sel);
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -386,11 +386,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
-				var sel = '.__ponzu-tag';
-				if (chip.tag.length > 0) {			
-					sel += '.';
-					sel += chip.tag.split(' ').join('.');
-				}
+				console.log(chip.tag);
+				var sel = '.__ponzu-tag' + '.' + chip.tag.split(' ').join('.');
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -386,6 +386,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
+				console.log(chip.id);
 				var sel = '.__ponzu-tag.' + chip.tag.split(' ').join('.');
 				chips.parent().find(sel).remove();
 

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -343,6 +343,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 	values := valueFromStructField(fieldName, p)
 	tags := strings.Split(values, "__ponzu")
 
+	fmt.Println(tags, len(tags))
+
 	html := `
 	<div class="col s12 __ponzu-tags ` + name + `">
 		<label class="active">` + attrs["label"] + ` (Type and press "Enter")</label>

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -410,7 +410,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 					});
 					
 					tags.append(input);
-					return;
+					// return;
 				}
 				
 				for (var i = 0; i < hidden.length; i++) {

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -387,7 +387,8 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
 				console.log(chip.tag);
-				var sel = '.__ponzu-tag' + chip.tag.split(' ').join('.');
+				var sel = '.__ponzu-tag.' + chip.tag.split(' ').join('.');
+				console.log(sel);
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -387,7 +387,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
 				console.log(chip.tag);
-				var sel = '.__ponzu-tag' + '.' + chip.tag.split(' ').join('.');
+				var sel = '.__ponzu-tag' + chip.tag.split(' ').join('.');
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -386,7 +386,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
-				console.log(chip.tag);
+				console.log(chip);
 				var sel = '.__ponzu-tag.' + chip.tag.split(' ').join('.');
 				console.log(sel);
 				chips.parent().find(sel).remove();

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -410,9 +410,9 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 					});
 					
 					tags.append(input);
-					// return;
 				}
 				
+				// re-name hidden storage elements in necessary format 
 				for (var i = 0; i < hidden.length; i++) {
 					$(hidden[i]).attr('name', '` + name + `.'+String(i));
 				}

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -341,10 +341,14 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 	// get the saved tags if this is already an existing post
 	values := valueFromStructField(fieldName, p)
-	fmt.Println(values)
 	var tags []string
 	if strings.Contains(values, "__ponzu") {
 		tags = strings.Split(values, "__ponzu")
+	}
+
+	// case where there is only one tag stored, thus has no separator
+	if len(values) > 0 && !strings.Contains(values, "__ponzu") {
+		tags = append(tags, values)
 	}
 
 	html := `

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -341,6 +341,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 	// get the saved tags if this is already an existing post
 	values := valueFromStructField(fieldName, p)
+	fmt.Println(values)
 	var tags []string
 	if strings.Contains(values, "__ponzu") {
 		tags = strings.Split(values, "__ponzu")

--- a/management/editor/elements.go
+++ b/management/editor/elements.go
@@ -375,7 +375,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 				
 				var input = $('<input>');
 				input.attr({
-					class: '__ponzu-tag '+chip.tag,
+					class: '__ponzu-tag '+chip.tag.split(' ').join('__'),
 					name: '` + name + `.'+String(tags.find('input[type=hidden]').length),
 					value: chip.tag,
 					type: 'hidden'
@@ -386,8 +386,7 @@ func Tags(fieldName string, p interface{}, attrs map[string]string) []byte {
 
 			chips.on('chip.delete', function(e, chip) {
 				// convert tag string to class-like selector "some tag" -> ".some.tag"
-				console.log(chip.id);
-				var sel = '.__ponzu-tag.' + chip.tag.split(' ').join('.');
+				var sel = '.__ponzu-tag.' + chip.tag.split(' ').join('__');
 				chips.parent().find(sel).remove();
 
 				// iterate through all hidden tag inputs to re-name them with the correct ` + name + `.index

--- a/management/manager/process.go
+++ b/management/manager/process.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/bosssauce/ponzu/management/editor"
+	"github.com/bosssauce/ponzu/content"
 
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 )
 
 // Slug returns a URL friendly string from the title of a post item
-func Slug(e editor.Editable) (string, error) {
+func Slug(i content.Identifiable) (string, error) {
 	// get the name of the post item
-	name := strings.TrimSpace(e.ContentName())
+	name := strings.TrimSpace(i.String())
 
 	// filter out non-alphanumeric character or non-whitespace
 	slug, err := stringToSlug(name)

--- a/system/admin/admin.go
+++ b/system/admin/admin.go
@@ -57,7 +57,7 @@ var mainAdminHTML = `
                                     
                     {{ range $t, $f := .Types }}
                     <div class="row collection-item">
-                        <li><a class="col s12" href="/admin/posts?type={{ $t }}"><i class="tiny left material-icons">playlist_add</i>{{ $t }}</a></li>
+                        <li><a class="col s12" href="/admin/contents?type={{ $t }}"><i class="tiny left material-icons">playlist_add</i>{{ $t }}</a></li>
                     </div>
                     {{ end }}
 

--- a/system/admin/admin.go
+++ b/system/admin/admin.go
@@ -259,6 +259,7 @@ var forgotPasswordHTML = `
             <label for="email" class="active">Email</label>
         </div>
         
+        <a href="/admin/recover/key">Already have a recovery key?</a>
         <button class="btn waves-effect waves-light right">Send Recovery Email</button>
     </form>
 </div>
@@ -304,7 +305,7 @@ var recoveryKeyHTML = `
 <div class="card-content">
     <div class="card-title">Account Recovery</div>
     <blockquote>Please check for your recovery key inside an email sent to the address you provided. Check your spam folder in case the message was flagged.</blockquote>
-    <form method="post" action="/admin/recover/key" class="row">
+    <form method="post" action="/admin/recover/key" class="row" enctype="multipart/form-data">
         <div class="input-field col s12">
             <input placeholder="Enter your recovery key" class="validate required" type="text" id="key" name="key"/>
             <label for="key" class="active">Recovery Key</label>

--- a/system/admin/admin.go
+++ b/system/admin/admin.go
@@ -205,7 +205,7 @@ var loginAdminHTML = `
         </div>
         <div class="input-field col s12">
             <input placeholder="Enter your password" class="validate required" type="password" id="password" name="password"/>
-            <a href="/admin/recover" class="right">Forgot password?</a>            
+            <a href="/admin/recover">Forgot password?</a>            
             <label for="password" class="active">Password</label>  
         </div>
         <button class="btn waves-effect waves-light right">Log in</button>

--- a/system/admin/admin.go
+++ b/system/admin/admin.go
@@ -253,7 +253,7 @@ var forgotPasswordHTML = `
 <div class="card-content">
     <div class="card-title">Account Recovery</div>
     <blockquote>Please enter the email for your account and a recovery message will be sent to you at this address. Check your spam folder in case the message was flagged.</blockquote>
-    <form method="post" action="/admin/recover" class="row">
+    <form method="post" action="/admin/recover" class="row" enctype="multipart/form-data">
         <div class="input-field col s12">
             <input placeholder="Enter your email address e.g. you@example.com" class="validate required" type="email" id="email" name="email"/>
             <label for="email" class="active">Email</label>

--- a/system/admin/config/config.go
+++ b/system/admin/config/config.go
@@ -18,8 +18,8 @@ type Config struct {
 	CacheInvalidate []string `json:"cache"`
 }
 
-// ContentName partially implements editor.Editable
-func (c *Config) ContentName() string { return c.Name }
+// String partially implements content.Identifiable and overrides Item's String()
+func (c *Config) String() string { return c.Name }
 
 // Editor partially implements editor.Editable
 func (c *Config) Editor() *editor.Editor { return &c.editor }

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -871,7 +871,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 					</div>`
 	if hasExt {
 		if status == "" {
-			q.Add("status", "public")
+			q.Set("status", "public")
 		}
 
 		// always start from top of results when changing public/pending
@@ -1355,7 +1355,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 		for name, urlPath := range urlPaths {
-			req.PostForm.Add(name, urlPath)
+			req.PostForm.Set(name, urlPath)
 		}
 
 		// check for any multi-value fields (ex. checkbox fields)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -656,8 +656,10 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 	case http.MethodPost:
 		err := req.ParseMultipartForm(1024 * 1024 * 4) // maxMemory 4MB
 		if err != nil {
-			res.WriteHeader(http.StatusInternalServerError)
 			log.Println("Error parsing recovery key form:", err)
+
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 
@@ -666,16 +668,20 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 		key := req.FormValue("key")
 
 		var actual string
-		if actual, err = db.RecoveryKey(email); err != nil {
-			res.WriteHeader(http.StatusInternalServerError)
+		if actual, err = db.RecoveryKey(email); err != nil || actual == "" {
 			log.Println("Error getting recovery key from database:", err)
+
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 
 		if key != actual {
-			res.WriteHeader(http.StatusBadRequest)
 			log.Println("Bad recovery key submitted:", key)
 			log.Println("Actual:", actual)
+
+			res.WriteHeader(http.StatusBadRequest)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 
@@ -683,21 +689,27 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 		usr := &user.User{}
 		u, err := db.User(email)
 		if err != nil {
-			res.WriteHeader(http.StatusInternalServerError)
 			log.Println("Error finding user by email:", email, err)
+
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 
 		if u == nil {
-			res.WriteHeader(http.StatusBadRequest)
 			log.Println("No user found with email:", email)
+
+			res.WriteHeader(http.StatusBadRequest)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 
 		err = json.Unmarshal(u, usr)
 		if err != nil {
-			res.WriteHeader(http.StatusInternalServerError)
 			log.Println("Error decoding user from database:", err)
+
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 
@@ -710,8 +722,10 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 
 		err = db.UpdateUser(usr, update)
 		if err != nil {
-			res.WriteHeader(http.StatusInternalServerError)
 			log.Println("Error updating user:", err)
+
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte("Error, please go back and try again."))
 			return
 		}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -970,9 +970,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// set up pagination values
-	urlFmt := req.URL.Path + "?count=%d&offset=%d&status=%s&type=%s"
-	prevURL := fmt.Sprintf(urlFmt, count, offset-1, status, t)
-	nextURL := fmt.Sprintf(urlFmt, count, offset+1, status, t)
+	urlFmt := req.URL.Path + "?count=%d&offset=%d&&order=%s&status=%s&type=%s"
+	prevURL := fmt.Sprintf(urlFmt, count, offset-1, order, status, t)
+	nextURL := fmt.Sprintf(urlFmt, count, offset+1, order, status, t)
 	start := 1 + count*offset
 	end := start + count - 1
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1677,7 +1677,7 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		post := adminPostListItem(p, t, "")
+		post := adminPostListItem(p, t, status)
 		b.Write([]byte(post))
 	}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -968,11 +968,12 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	urlFmt := req.URL.Path + "?count=%d&offset=%d&status=%s&type=%s"
 	prevURL := fmt.Sprintf(urlFmt, count, offset-1, status, t)
 	nextURL := fmt.Sprintf(urlFmt, count, offset+1, status, t)
-	start := 1 + count*offset
-	end := start + count - 1
+	// total may be less than 10 (default count), so reset count to match total
 	if total < count {
 		count = total
 	}
+	start := 1 + count*offset
+	end := start + count - 1
 
 	pagination := fmt.Sprintf(`
 	<ul class="pagination row">

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -1071,7 +1071,7 @@ func adminPostListItem(e editor.Editable, typeName, status string) []byte {
 
 	post := `
 			<li class="col s12">
-				<a href="/admin/edit?type=` + typeName + `&status=` + strings.TrimPrefix(status, "_") + `&id=` + cid + `">` + e.ContentName() + `</a>
+				<a href="/admin/edit?type=` + typeName + `&status=` + strings.TrimPrefix(status, "_") + `&id=` + cid + `">` + i.String() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -686,6 +686,7 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 		// set user with new password
+		password := req.FormValue("password")
 		usr := &user.User{}
 		u, err := db.User(email)
 		if err != nil {
@@ -713,12 +714,8 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		update := &user.User{
-			ID:    usr.ID,
-			Email: usr.Email,
-			Hash:  usr.Hash,
-			Salt:  usr.Salt,
-		}
+		update := user.NewUser(email, password)
+		update.ID = usr.ID
 
 		err = db.UpdateUser(usr, update)
 		if err != nil {

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -866,6 +866,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 							<i class="right material-icons search-icon">search</i>
 							<input class="search" name="q" type="text" placeholder="Within all ` + t + ` fields" class="search"/>
 							<input type="hidden" name="type" value="` + t + `" />
+							<input type="hidden" name="status" value="` + status + `" />
 						</div>
                     </form>	
 					</div>`
@@ -1627,13 +1628,19 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 	q := req.URL.Query()
 	t := q.Get("type")
 	search := q.Get("q")
+	status := q.Get("status")
+	var specifier string
 
 	if t == "" || search == "" {
 		http.Redirect(res, req, req.URL.Scheme+req.URL.Host+"/admin", http.StatusFound)
 		return
 	}
 
-	posts := db.ContentAll(t)
+	if status == "pending" {
+		specifier = "_" + status
+	}
+
+	posts := db.ContentAll(t + specifier)
 	b := &bytes.Buffer{}
 	p := content.Types[t]().(editor.Editable)
 
@@ -1641,11 +1648,13 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 					<div class="card-content">
 					<div class="row">
 					<div class="card-title col s7">` + t + ` Results</div>	
-					<form class="col s5" action="/admin/posts/search" method="get">
+					<form class="col s4" action="/admin/posts/search" method="get">
 						<div class="input-field post-search inline">
+							<label class="active">Search:</label>
 							<i class="right material-icons search-icon">search</i>
-							<input class="search" name="q" type="text" placeholder="Search for ` + t + ` content" class="search"/>
+							<input class="search" name="q" type="text" placeholder="Within all ` + t + ` fields" class="search"/>
 							<input type="hidden" name="type" value="` + t + `" />
+							<input type="hidden" name="status" value="` + status + `" />
 						</div>
                     </form>	
 					</div>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -675,6 +675,7 @@ func recoveryKeyHandler(res http.ResponseWriter, req *http.Request) {
 		if key != actual {
 			res.WriteHeader(http.StatusBadRequest)
 			log.Println("Bad recovery key submitted:", key)
+			log.Println("Actual:", actual)
 			return
 		}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -589,22 +589,23 @@ func forgotPasswordHandler(res http.ResponseWriter, req *http.Request) {
 		}
 
 		body := fmt.Sprintf(`
-		There has been an account recovery request made for the user with email:
-		%s
+There has been an account recovery request made for the user with email:
+%s
 
-		To recover your account, please go to http://%s/admin/recover/key and enter 
-		this email address along with the following secret key:
-		
-		%s
+To recover your account, please go to http://%s/admin/recover/key and enter 
+this email address along with the following secret key:
 
-		If you did not make the request, ignore this message and your password 
-		will remain as-is.
+%s
+
+If you did not make the request, ignore this message and your password 
+will remain as-is.
 
 
-		Thank you,
-		Ponzu CMS at %s
+Thank you,
+Ponzu CMS at %s
 
-		`, email, domain, key, domain)
+`, email, domain, key, domain)
+
 		msg := emailer.Message{
 			To:      email,
 			From:    fmt.Sprintf("Ponzu CMS <ponzu-cms@%s>", domain),
@@ -612,20 +613,12 @@ func forgotPasswordHandler(res http.ResponseWriter, req *http.Request) {
 			Body:    body,
 		}
 
-		/*
+		go func() {
 			err = msg.Send()
 			if err != nil {
-				res.WriteHeader(http.StatusInternalServerError)
-				errView, err := Error500()
-				if err != nil {
-					return
-				}
-
-				res.Write(errView)
-				return
+				log.Println("Failed to send message to:", msg.To, "about", msg.Subject, "Error:", err)
 			}
-		*/
-		fmt.Println(msg)
+		}()
 
 		// redirect to /admin/recover/key and send email with key and URL
 		http.Redirect(res, req, req.URL.Scheme+req.URL.Host+"/admin/recover/key", http.StatusFound)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -971,7 +971,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	start := 1 + count*offset
 	end := start + count - 1
 	if total < count {
-		total = count
+		count = total
 	}
 
 	pagination := fmt.Sprintf(`

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -964,7 +964,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		nextStatus = statusDisabled
 	}
 
-	urlFmt := req.URL.Path + "/admin/posts?count=%d&offset=%d&status=%s&type=%s"
+	urlFmt := req.URL.Path + "?count=%d&offset=%d&status=%s&type=%s"
 	prevURL := fmt.Sprintf(urlFmt, count, offset-1, status, t)
 	nextURL := fmt.Sprintf(urlFmt, count, offset+1, status, t)
 	start := 1 + count*offset

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -976,6 +976,10 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	start := 1 + count*offset
 	end := start + count - 1
 
+	if total < end {
+		end = total
+	}
+
 	pagination := fmt.Sprintf(`
 	<ul class="pagination row">
 		<li class="col s2 waves-effect %s"><a href="%s"><i class="material-icons">chevron_left</i></a></li>
@@ -983,6 +987,18 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		<li class="col s2 waves-effect %s"><a href="%s"><i class="material-icons">chevron_right</i></a></li>
 	</ul>
 	`, prevStatus, prevURL, start, end, total, nextStatus, nextURL)
+
+	// show indicator that a collection of items will be listed implicitly, but
+	// that none are created yet
+	if total < 1 {
+		pagination = `
+		<ul class="pagination row">
+			<li class="col s2 waves-effect disabled"><a href="#"><i class="material-icons">chevron_left</i></a></li>
+			<li class="col s8">0 to 0 of 0</li>
+			<li class="col s2 waves-effect disabled"><a href="#"><i class="material-icons">chevron_right</i></a></li>
+		</ul>
+		`
+	}
 
 	b.Write([]byte(pagination + `</div></div>`))
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -965,7 +965,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		prevStatus = statusDisabled
 	}
 	// nothing after current list
-	if offset*count >= total {
+	if (offset+1)*count >= total {
 		nextStatus = statusDisabled
 	}
 
@@ -978,9 +978,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 	pagination := fmt.Sprintf(`
 	<ul class="pagination row">
-		<li class="waves-effect col s4 %s"><a href="%s"><i class="material-icons">chevron_left</i></a></li>
-		<li class="col s4">%d to %d of %d</li>
-		<li class="waves-effect col s4 %s"><a href="%s"><i class="material-icons">chevron_right</i></a></li>
+		<li class="waves-effect %s"><a href="%s"><i class="col s2 material-icons">chevron_left</i></a></li>
+		<li class="col s8">%d to %d of %d</li>
+		<li class="waves-effect %s"><a href="%s"><i class="col s2 material-icons">chevron_right</i></a></li>
 	</ul>
 	`, prevStatus, prevURL, start, end, total, nextStatus, nextURL)
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -964,17 +964,30 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		nextStatus = statusDisabled
 	}
 
+	// set up pagination values
 	urlFmt := req.URL.Path + "?count=%d&offset=%d&status=%s&type=%s"
 	prevURL := fmt.Sprintf(urlFmt, count, offset-1, status, t)
 	nextURL := fmt.Sprintf(urlFmt, count, offset+1, status, t)
 	start := 1 + count*offset
-	end := start + count
+	end := start + count - 1
+	if total < count {
+		total = count
+	}
+
 	pagination := fmt.Sprintf(`
 	<ul class="pagination row">
 		<li class="waves-effect col s4 %s"><a href="%s"><i class="material-icons">chevron_left</i></a></li>
 		<li class="col s4">%d to %d of %d</li>
 		<li class="waves-effect col s4 %s"><a href="%s"><i class="material-icons">chevron_right</i></a></li>
 	</ul>
+	<script>
+		// disable link from being clicked if parent is 'disabled'
+		$(function() {
+			$('li.disabled a').on('click', function(e) {
+				e.preventDefault();
+			});
+		});
+	</script>
 	`, prevStatus, prevURL, start, end, total, nextStatus, nextURL)
 
 	b.Write([]byte(pagination + `</div></div>`))

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -556,35 +556,20 @@ func forgotPasswordHandler(res http.ResponseWriter, req *http.Request) {
 		email := strings.ToLower(req.FormValue("email"))
 		if email == "" {
 			res.WriteHeader(http.StatusBadRequest)
-			errView, err := Error400()
-			if err != nil {
-				return
-			}
-
-			res.Write(errView)
+			fmt.Println("Email was empty.")
 			return
 		}
 
 		_, err = db.User(email)
 		if err == db.ErrNoUserExists {
 			res.WriteHeader(http.StatusBadRequest)
-			errView, err := Error400()
-			if err != nil {
-				return
-			}
-
-			res.Write(errView)
+			fmt.Println("No user exists.")
 			return
 		}
 
 		if err != db.ErrNoUserExists && err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
-			errView, err := Error500()
-			if err != nil {
-				return
-			}
-
-			res.Write(errView)
+			fmt.Println("Error:", err)
 			return
 		}
 
@@ -592,12 +577,7 @@ func forgotPasswordHandler(res http.ResponseWriter, req *http.Request) {
 		key, err := db.SetRecoveryKey(email)
 		if err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
-			errView, err := Error500()
-			if err != nil {
-				return
-			}
-
-			res.Write(errView)
+			fmt.Println("Failed to set key.", err)
 			return
 		}
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -608,7 +608,7 @@ Ponzu CMS at %s
 
 		msg := emailer.Message{
 			To:      email,
-			From:    fmt.Sprintf("Ponzu CMS <ponzu-cms@%s>", domain),
+			From:    fmt.Sprintf("ponzu@%s", domain),
 			Subject: fmt.Sprintf("Account Recovery [%s]", domain),
 			Body:    body,
 		}

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -733,7 +733,7 @@ func recoveryEditHandler(res http.ResponseWriter, req *http.Request) {
 
 }
 
-func postsHandler(res http.ResponseWriter, req *http.Request) {
+func contentsHandler(res http.ResponseWriter, req *http.Request) {
 	q := req.URL.Query()
 	t := q.Get("type")
 	if t == "" {
@@ -860,7 +860,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 							</script>
 						</div>
 					</div>
-					<form class="col s4" action="/admin/posts/search" method="get">
+					<form class="col s4" action="/admin/contents/search" method="get">
 						<div class="input-field post-search inline">
 							<label class="active">Search:</label>
 							<i class="right material-icons search-icon">search</i>
@@ -1086,7 +1086,7 @@ func adminPostListItem(e editor.Editable, typeName, status string) []byte {
 	return []byte(post)
 }
 
-func approvePostHandler(res http.ResponseWriter, req *http.Request) {
+func approveContentHandler(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		res.WriteHeader(http.StatusMethodNotAllowed)
 		errView, err := Error405()
@@ -1603,7 +1603,7 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	redir := strings.TrimSuffix(req.URL.Scheme+req.URL.Host+req.URL.Path, "/edit/delete")
-	redir = redir + "/posts?type=" + ct
+	redir = redir + "/contents?type=" + ct
 	http.Redirect(res, req, redir, http.StatusFound)
 }
 
@@ -1648,7 +1648,7 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 					<div class="card-content">
 					<div class="row">
 					<div class="card-title col s7">` + t + ` Results</div>	
-					<form class="col s4" action="/admin/posts/search" method="get">
+					<form class="col s4" action="/admin/contents/search" method="get">
 						<div class="input-field post-search inline">
 							<label class="active">Search:</label>
 							<i class="right material-icons search-icon">search</i>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -911,7 +911,21 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 	html += `<ul class="posts row">`
 
-	b.Write([]byte(`</ul></div></div>`))
+	b.Write([]byte(`</ul>`))
+
+	pagination := `
+	<ul class="pagination">
+		<li class="disabled"><a href="#!"><i class="material-icons">chevron_left</i></a></li>
+		<li class="active"><a href="#!">1</a></li>
+		<li class="waves-effect"><a href="#!">2</a></li>
+		<li class="waves-effect"><a href="#!">3</a></li>
+		<li class="waves-effect"><a href="#!">4</a></li>
+		<li class="waves-effect"><a href="#!">5</a></li>
+		<li class="waves-effect"><a href="#!"><i class="material-icons">chevron_right</i></a></li>
+	</ul>
+	`
+
+	b.Write([]byte(pagination + `</div></div>`))
 
 	script := `
 	<script>

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -978,9 +978,9 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 
 	pagination := fmt.Sprintf(`
 	<ul class="pagination row">
-		<li class="waves-effect %s"><a href="%s"><i class="col s2 material-icons">chevron_left</i></a></li>
+		<li class="col s2 waves-effect %s"><a href="%s"><i class="material-icons">chevron_left</i></a></li>
 		<li class="col s8">%d to %d of %d</li>
-		<li class="waves-effect %s"><a href="%s"><i class="col s2 material-icons">chevron_right</i></a></li>
+		<li class="col s2 waves-effect %s"><a href="%s"><i class="material-icons">chevron_right</i></a></li>
 	</ul>
 	`, prevStatus, prevURL, start, end, total, nextStatus, nextURL)
 

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -823,7 +823,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 		Order:  order,
 	}
 
-	total, posts := db.Query(t+"_sorted", opts)
+	total, posts := db.Query(t+"__sorted", opts)
 	b := &bytes.Buffer{}
 
 	html := `<div class="col s9 card">		
@@ -909,8 +909,8 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 			}
 
 		case "pending":
-			// get _pending posts of type t from the db
-			_, posts = db.Query(t+"_pending", opts)
+			// get __pending posts of type t from the db
+			_, posts = db.Query(t+"__pending", opts)
 
 			html += `<div class="row externalable">
 					<span class="description">Status:</span> 
@@ -1039,7 +1039,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 
 // adminPostListItem is a helper to create the li containing a post.
 // p is the asserted post as an Editable, t is the Type of the post.
-// specifier is passed to append a name to a namespace like _pending
+// specifier is passed to append a name to a namespace like __pending
 func adminPostListItem(e editor.Editable, typeName, status string) []byte {
 	s, ok := e.(editor.Sortable)
 	if !ok {
@@ -1067,12 +1067,12 @@ func adminPostListItem(e editor.Editable, typeName, status string) []byte {
 	case "public", "":
 		status = ""
 	default:
-		status = "_" + status
+		status = "__" + status
 	}
 
 	post := `
 			<li class="col s12">
-				<a href="/admin/edit?type=` + typeName + `&status=` + strings.TrimPrefix(status, "_") + `&id=` + cid + `">` + i.String() + `</a>
+				<a href="/admin/edit?type=` + typeName + `&status=` + strings.TrimPrefix(status, "__") + `&id=` + cid + `">` + i.String() + `</a>
 				<span class="post-detail">Updated: ` + updatedTime + `</span>
 				<span class="publish-date right">` + publishTime + `</span>
 
@@ -1111,8 +1111,8 @@ func approveContentHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	t := req.FormValue("type")
-	if strings.Contains(t, "_") {
-		t = strings.Split(t, "_")[0]
+	if strings.Contains(t, "__") {
+		t = strings.Split(t, "__")[0]
 	}
 
 	post := content.Types[t]()
@@ -1257,7 +1257,7 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 
 		if i != "" {
 			if status == "pending" {
-				t = t + "_pending"
+				t = t + "__pending"
 			}
 
 			data, err := db.Content(t + ":" + i)
@@ -1396,8 +1396,8 @@ func editHandler(res http.ResponseWriter, req *http.Request) {
 			req.PostForm.Del(discardKey)
 		}
 
-		if strings.Contains(t, "_") {
-			t = strings.Split(t, "_")[0]
+		if strings.Contains(t, "__") {
+			t = strings.Split(t, "__")[0]
 		}
 
 		p, ok := content.Types[t]
@@ -1506,8 +1506,8 @@ func deleteHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// catch specifier suffix from delete form value
-	if strings.Contains(t, "_") {
-		spec := strings.Split(t, "_")
+	if strings.Contains(t, "__") {
+		spec := strings.Split(t, "__")
 		ct = spec[0]
 	}
 
@@ -1637,7 +1637,7 @@ func searchHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	if status == "pending" {
-		specifier = "_" + status
+		specifier = "__" + status
 	}
 
 	posts := db.ContentAll(t + specifier)

--- a/system/admin/handlers.go
+++ b/system/admin/handlers.go
@@ -956,10 +956,15 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	statusDisabled := "disabled"
 	prevStatus := ""
 	nextStatus := ""
+	// total may be less than 10 (default count), so reset count to match total
+	if total < count {
+		count = total
+	}
+	// nothing previous to current list
 	if offset == 0 {
 		prevStatus = statusDisabled
 	}
-
+	// nothing after current list
 	if offset*count >= total {
 		nextStatus = statusDisabled
 	}
@@ -968,10 +973,6 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	urlFmt := req.URL.Path + "?count=%d&offset=%d&status=%s&type=%s"
 	prevURL := fmt.Sprintf(urlFmt, count, offset-1, status, t)
 	nextURL := fmt.Sprintf(urlFmt, count, offset+1, status, t)
-	// total may be less than 10 (default count), so reset count to match total
-	if total < count {
-		count = total
-	}
 	start := 1 + count*offset
 	end := start + count - 1
 
@@ -981,14 +982,6 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		<li class="col s4">%d to %d of %d</li>
 		<li class="waves-effect col s4 %s"><a href="%s"><i class="material-icons">chevron_right</i></a></li>
 	</ul>
-	<script>
-		// disable link from being clicked if parent is 'disabled'
-		$(function() {
-			$('li.disabled a').on('click', function(e) {
-				e.preventDefault();
-			});
-		});
-	</script>
 	`, prevStatus, prevURL, start, end, total, nextStatus, nextURL)
 
 	b.Write([]byte(pagination + `</div></div>`))
@@ -1001,6 +994,13 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 				if (confirm("[Ponzu] Please confirm:\n\nAre you sure you want to delete this post?\nThis cannot be undone.")) {
 					$(e.target).parent().submit();
 				}
+			});
+		});
+
+		// disable link from being clicked if parent is 'disabled'
+		$(function() {
+			$('ul.pagination li.disabled a').on('click', function(e) {
+				e.preventDefault();
 			});
 		});
 	</script>

--- a/system/admin/server.go
+++ b/system/admin/server.go
@@ -27,12 +27,12 @@ func Run() {
 	http.HandleFunc("/admin/configure/users/edit", user.Auth(configUsersEditHandler))
 	http.HandleFunc("/admin/configure/users/delete", user.Auth(configUsersDeleteHandler))
 
-	http.HandleFunc("/admin/posts", user.Auth(postsHandler))
-	http.HandleFunc("/admin/posts/search", user.Auth(searchHandler))
+	http.HandleFunc("/admin/contents", user.Auth(contentsHandler))
+	http.HandleFunc("/admin/contents/search", user.Auth(searchHandler))
 
 	http.HandleFunc("/admin/edit", user.Auth(editHandler))
 	http.HandleFunc("/admin/edit/delete", user.Auth(deleteHandler))
-	http.HandleFunc("/admin/edit/approve", user.Auth(approvePostHandler))
+	http.HandleFunc("/admin/edit/approve", user.Auth(approveContentHandler))
 	http.HandleFunc("/admin/edit/upload", user.Auth(editUploadHandler))
 
 	pwd, err := os.Getwd()

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -66,7 +66,7 @@ func Init() {
 	}
 
 	err = store.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists([]byte("requests"))
+		_, err := tx.CreateBucketIfNotExists([]byte("__requests"))
 		if err != nil {
 			return err
 		}

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -138,7 +138,7 @@ func ChartData() (map[string]interface{}, error) {
 	// get api request analytics from db
 	var requests = []apiRequest{}
 	err := store.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("requests"))
+		b := tx.Bucket([]byte("__requests"))
 
 		err := b.ForEach(func(k, v []byte) error {
 			var r apiRequest

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -15,8 +15,14 @@ import (
 // Externalable accepts or rejects external POST requests to endpoints such as:
 // /external/content?type=Review
 type Externalable interface {
-	// Accepts determines whether a type will allow external submissions
-	Accepts() bool
+	// Accept allows external content submissions of a specific type
+	Accept(req *http.Request) error
+}
+
+// Trustable allows external content to be auto-approved, meaning content sent
+// as an Externalable will be stored in the public content bucket
+type Trustable interface {
+	AutoApprove(req *http.Request) error
 }
 
 func externalPostHandler(res http.ResponseWriter, req *http.Request) {
@@ -54,69 +60,93 @@ func externalPostHandler(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if ext.Accepts() {
-		ts := fmt.Sprintf("%d", time.Now().Unix()*1000)
-		req.PostForm.Set("timestamp", ts)
-		req.PostForm.Set("updated", ts)
+	ts := fmt.Sprintf("%d", time.Now().Unix()*1000)
+	req.PostForm.Set("timestamp", ts)
+	req.PostForm.Set("updated", ts)
 
-		urlPaths, err := upload.StoreFiles(req)
-		if err != nil {
-			log.Println(err)
-			res.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	urlPaths, err := upload.StoreFiles(req)
+	if err != nil {
+		log.Println(err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-		for name, urlPath := range urlPaths {
-			req.PostForm.Add(name, urlPath)
-		}
+	for name, urlPath := range urlPaths {
+		req.PostForm.Add(name, urlPath)
+	}
 
-		// check for any multi-value fields (ex. checkbox fields)
-		// and correctly format for db storage. Essentially, we need
-		// fieldX.0: value1, fieldX.1: value2 => fieldX: []string{value1, value2}
-		var discardKeys []string
-		for k, v := range req.PostForm {
-			if strings.Contains(k, ".") {
-				key := strings.Split(k, ".")[0]
+	// check for any multi-value fields (ex. checkbox fields)
+	// and correctly format for db storage. Essentially, we need
+	// fieldX.0: value1, fieldX.1: value2 => fieldX: []string{value1, value2}
+	var discardKeys []string
+	for k, v := range req.PostForm {
+		if strings.Contains(k, ".") {
+			key := strings.Split(k, ".")[0]
 
-				if req.PostForm.Get(key) == "" {
-					req.PostForm.Set(key, v[0])
-					discardKeys = append(discardKeys, k)
-				} else {
-					req.PostForm.Add(key, v[0])
-				}
+			if req.PostForm.Get(key) == "" {
+				req.PostForm.Set(key, v[0])
+				discardKeys = append(discardKeys, k)
+			} else {
+				req.PostForm.Add(key, v[0])
 			}
 		}
-
-		for _, discardKey := range discardKeys {
-			req.PostForm.Del(discardKey)
-		}
-
-		hook, ok := post.(content.Hookable)
-		if !ok {
-			log.Println("[External] error: Type", t, "does not implement content.Hookable or embed content.Item.")
-			res.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		err = hook.BeforeSave(req)
-		if err != nil {
-			log.Println("[External] error:", err)
-			res.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		_, err = db.SetContent(t+"_pending:-1", req.PostForm)
-		if err != nil {
-			log.Println("[External] error:", err)
-			res.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		err = hook.AfterSave(req)
-		if err != nil {
-			log.Println("[External] error:", err)
-			res.WriteHeader(http.StatusInternalServerError)
-			return
-		}
 	}
+
+	for _, discardKey := range discardKeys {
+		req.PostForm.Del(discardKey)
+	}
+
+	// call Accept with the request, enabling developer to add or chack data
+	// before saving to DB
+	err = ext.Accept(req)
+	if err != nil {
+		log.Println(err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	hook, ok := post.(content.Hookable)
+	if !ok {
+		log.Println("[External] error: Type", t, "does not implement content.Hookable or embed content.Item.")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = hook.BeforeSave(req)
+	if err != nil {
+		log.Println("[External] error:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// set specifier for db bucket in case content is/isn't Trustable
+	var spec string
+
+	// check if the content is Trustable should be auto-approved
+	trusted, ok := post.(Trustable)
+	if ok {
+		err := trusted.AutoApprove(req)
+		if err != nil {
+			log.Println("[External] error:", err)
+			res.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	} else {
+		spec = "_pending"
+	}
+
+	_, err = db.SetContent(t+spec+":-1", req.PostForm)
+	if err != nil {
+		log.Println("[External] error:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = hook.AfterSave(req)
+	if err != nil {
+		log.Println("[External] error:", err)
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 }

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -72,7 +72,7 @@ func externalPostHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	for name, urlPath := range urlPaths {
-		req.PostForm.Add(name, urlPath)
+		req.PostForm.Set(name, urlPath)
 	}
 
 	// check for any multi-value fields (ex. checkbox fields)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -132,7 +132,7 @@ func externalContentHandler(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 	} else {
-		spec = "_pending"
+		spec = "__pending"
 	}
 
 	_, err = db.SetContent(t+spec+":-1", req.PostForm)

--- a/system/api/external.go
+++ b/system/api/external.go
@@ -25,7 +25,7 @@ type Trustable interface {
 	AutoApprove(req *http.Request) error
 }
 
-func externalPostHandler(res http.ResponseWriter, req *http.Request) {
+func externalContentHandler(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		res.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -28,7 +28,7 @@ func typesHandler(res http.ResponseWriter, req *http.Request) {
 	sendData(res, j, http.StatusOK)
 }
 
-func postsHandler(res http.ResponseWriter, req *http.Request) {
+func contentsHandler(res http.ResponseWriter, req *http.Request) {
 	q := req.URL.Query()
 	t := q.Get("type")
 	if t == "" {
@@ -87,7 +87,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 	sendData(res, j, http.StatusOK)
 }
 
-func postHandler(res http.ResponseWriter, req *http.Request) {
+func contentHandler(res http.ResponseWriter, req *http.Request) {
 	q := req.URL.Query()
 	id := q.Get("id")
 	t := q.Get("type")

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -72,7 +72,7 @@ func contentsHandler(res http.ResponseWriter, req *http.Request) {
 		Order:  order,
 	}
 
-	_, bb := db.Query(t+"_sorted", opts)
+	_, bb := db.Query(t+"__sorted", opts)
 	var result = []json.RawMessage{}
 	for i := range bb {
 		result = append(result, bb[i])

--- a/system/api/handlers.go
+++ b/system/api/handlers.go
@@ -72,7 +72,7 @@ func postsHandler(res http.ResponseWriter, req *http.Request) {
 		Order:  order,
 	}
 
-	bb := db.Query(t+"_sorted", opts)
+	_, bb := db.Query(t+"_sorted", opts)
 	var result = []json.RawMessage{}
 	for i := range bb {
 		result = append(result, bb[i])

--- a/system/api/server.go
+++ b/system/api/server.go
@@ -8,9 +8,9 @@ import (
 func Run() {
 	http.HandleFunc("/api/types", CORS(Record(typesHandler)))
 
-	http.HandleFunc("/api/contents", CORS(Record(postsHandler)))
+	http.HandleFunc("/api/contents", CORS(Record(contentsHandler)))
 
-	http.HandleFunc("/api/content", CORS(Record(postHandler)))
+	http.HandleFunc("/api/content", CORS(Record(contentHandler)))
 
-	http.HandleFunc("/api/content/external", CORS(Record(externalPostHandler)))
+	http.HandleFunc("/api/content/external", CORS(Record(externalContentHandler)))
 }

--- a/system/db/config.go
+++ b/system/db/config.go
@@ -24,7 +24,7 @@ func init() {
 // SetConfig sets key:value pairs in the db for configuration settings
 func SetConfig(data url.Values) error {
 	err := store.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("_config"))
+		b := tx.Bucket([]byte("__config"))
 
 		// check for any multi-value fields (ex. checkbox fields)
 		// and correctly format for db storage. Essentially, we need
@@ -108,7 +108,7 @@ func Config(key string) ([]byte, error) {
 func ConfigAll() ([]byte, error) {
 	val := &bytes.Buffer{}
 	err := store.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("_config"))
+		b := tx.Bucket([]byte("__config"))
 		val.Write(b.Get([]byte("settings")))
 
 		return nil

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -334,7 +334,7 @@ func SortContent(namespace string) {
 
 	all := ContentAll(namespace)
 
-	var posts sortablePosts
+	var posts sortableContent
 	// decode each (json) into type to then sort
 	for i := range all {
 		j := all[i]
@@ -387,17 +387,17 @@ func SortContent(namespace string) {
 
 }
 
-type sortableContents []editor.Sortable
+type sortableContent []editor.Sortable
 
-func (s sortableContents) Len() int {
+func (s sortableContent) Len() int {
 	return len(s)
 }
 
-func (s sortableContents) Less(i, j int) bool {
+func (s sortableContent) Less(i, j int) bool {
 	return s[i].Time() > s[j].Time()
 }
 
-func (s sortableContents) Swap(i, j int) {
+func (s sortableContent) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -403,7 +403,6 @@ func (s sortablePosts) Swap(i, j int) {
 
 func postToJSON(ns string, data url.Values) ([]byte, error) {
 	// find the content type and decode values into it
-	ns = strings.TrimSuffix(ns, "_external")
 	t, ok := content.Types[ns]
 	if !ok {
 		return nil, fmt.Errorf(content.ErrTypeNotRegistered, ns)

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -39,11 +39,11 @@ func SetContent(target string, data url.Values) (int, error) {
 }
 
 func update(ns, id string, data url.Values) (int, error) {
-	var specifier string // i.e. _pending, _sorted, etc.
-	if strings.Contains(ns, "_") {
-		spec := strings.Split(ns, "_")
+	var specifier string // i.e. __pending, __sorted, etc.
+	if strings.Contains(ns, "__") {
+		spec := strings.Split(ns, "__")
 		ns = spec[0]
-		specifier = "_" + spec[1]
+		specifier = "__" + spec[1]
 	}
 
 	cid, err := strconv.Atoi(id)
@@ -82,11 +82,11 @@ func update(ns, id string, data url.Values) (int, error) {
 
 func insert(ns string, data url.Values) (int, error) {
 	var effectedID int
-	var specifier string // i.e. _pending, _sorted, etc.
-	if strings.Contains(ns, "_") {
-		spec := strings.Split(ns, "_")
+	var specifier string // i.e. __pending, __sorted, etc.
+	if strings.Contains(ns, "__") {
+		spec := strings.Split(ns, "__")
 		ns = spec[0]
-		specifier = "_" + spec[1]
+		specifier = "__" + spec[1]
 	}
 
 	err := store.Update(func(tx *bolt.Tx) error {
@@ -328,7 +328,7 @@ func Query(namespace string, opts QueryOptions) (int, [][]byte) {
 // Should be called from a goroutine after SetContent is successful
 func SortContent(namespace string) {
 	// only sort main content types i.e. Post
-	if strings.Contains(namespace, "_") {
+	if strings.Contains(namespace, "__") {
 		return
 	}
 
@@ -354,7 +354,7 @@ func SortContent(namespace string) {
 
 	// store in <namespace>_sorted bucket, first delete existing
 	err := store.Update(func(tx *bolt.Tx) error {
-		bname := []byte(namespace + "_sorted")
+		bname := []byte(namespace + "__sorted")
 		err := tx.DeleteBucket(bname)
 		if err != nil {
 			return err

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -418,7 +418,7 @@ func postToJSON(ns string, data url.Values) ([]byte, error) {
 		return nil, err
 	}
 
-	slug, err := manager.Slug(post.(editor.Editable))
+	slug, err := manager.Slug(post.(content.Identifiable))
 	if err != nil {
 		return nil, err
 	}

--- a/system/db/content.go
+++ b/system/db/content.go
@@ -387,17 +387,17 @@ func SortContent(namespace string) {
 
 }
 
-type sortablePosts []editor.Sortable
+type sortableContents []editor.Sortable
 
-func (s sortablePosts) Len() int {
+func (s sortableContents) Len() int {
 	return len(s)
 }
 
-func (s sortablePosts) Less(i, j int) bool {
+func (s sortableContents) Less(i, j int) bool {
 	return s[i].Time() > s[j].Time()
 }
 
-func (s sortablePosts) Swap(i, j int) {
+func (s sortableContents) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 

--- a/system/db/init.go
+++ b/system/db/init.go
@@ -38,14 +38,14 @@ func Init() {
 				return err
 			}
 
-			_, err = tx.CreateBucketIfNotExists([]byte(t + "_sorted"))
+			_, err = tx.CreateBucketIfNotExists([]byte(t + "__sorted"))
 			if err != nil {
 				return err
 			}
 		}
 
 		// init db with other buckets as needed
-		buckets := []string{"_config", "_users"}
+		buckets := []string{"__config", "__users"}
 		for _, name := range buckets {
 			_, err := tx.CreateBucketIfNotExists([]byte(name))
 			if err != nil {
@@ -54,7 +54,7 @@ func Init() {
 		}
 
 		// seed db with configs structure if not present
-		b := tx.Bucket([]byte("_config"))
+		b := tx.Bucket([]byte("__config"))
 		if b.Get([]byte("settings")) == nil {
 			j, err := json.Marshal(&config.Config{})
 			if err != nil {
@@ -93,7 +93,7 @@ func SystemInitComplete() bool {
 	complete := false
 
 	err := store.View(func(tx *bolt.Tx) error {
-		users := tx.Bucket([]byte("_users"))
+		users := tx.Bucket([]byte("__users"))
 
 		err := users.ForEach(func(k, v []byte) error {
 			complete = true

--- a/system/db/user.go
+++ b/system/db/user.go
@@ -226,7 +226,7 @@ func RecoveryKey(email string) (string, error) {
 			return errors.New("No database found for checking keys.")
 		}
 
-		_, err := key.Write(b.Get([]byte("email")))
+		_, err := key.Write(b.Get([]byte(email)))
 		if err != nil {
 			return err
 		}

--- a/system/db/user.go
+++ b/system/db/user.go
@@ -61,6 +61,11 @@ func SetUser(usr *user.User) (int, error) {
 
 // UpdateUser sets key:value pairs in the db for existing user settings
 func UpdateUser(usr, updatedUsr *user.User) error {
+	// ensure user ID remains the same
+	if updatedUsr.ID != usr.ID {
+		updatedUsr.ID = usr.ID
+	}
+
 	err := store.Update(func(tx *bolt.Tx) error {
 		users := tx.Bucket([]byte("_users"))
 

--- a/system/db/user.go
+++ b/system/db/user.go
@@ -215,8 +215,8 @@ func SetRecoveryKey(email string) (string, error) {
 	return key, nil
 }
 
-// RecoveryKey generates and saves a random secret key to verify an email
-// address submitted in order to recover/reset an account password
+// RecoveryKey gets a previously set recovery key to verify an email address
+// submitted in order to recover/reset an account password
 func RecoveryKey(email string) (string, error) {
 	key := &bytes.Buffer{}
 

--- a/system/db/user.go
+++ b/system/db/user.go
@@ -24,7 +24,7 @@ var ErrNoUserExists = errors.New("Error. No user exists.")
 func SetUser(usr *user.User) (int, error) {
 	err := store.Update(func(tx *bolt.Tx) error {
 		email := []byte(usr.Email)
-		users := tx.Bucket([]byte("_users"))
+		users := tx.Bucket([]byte("__users"))
 
 		// check if user is found by email, fail if nil
 		exists := users.Get(email)
@@ -67,7 +67,7 @@ func UpdateUser(usr, updatedUsr *user.User) error {
 	}
 
 	err := store.Update(func(tx *bolt.Tx) error {
-		users := tx.Bucket([]byte("_users"))
+		users := tx.Bucket([]byte("__users"))
 
 		// check if user is found by email, fail if nil
 		exists := users.Get([]byte(usr.Email))
@@ -108,7 +108,7 @@ func UpdateUser(usr, updatedUsr *user.User) error {
 // DeleteUser deletes a user from the db by email
 func DeleteUser(email string) error {
 	err := store.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("_users"))
+		b := tx.Bucket([]byte("__users"))
 		err := b.Delete([]byte(email))
 		if err != nil {
 			return err
@@ -127,7 +127,7 @@ func DeleteUser(email string) error {
 func User(email string) ([]byte, error) {
 	val := &bytes.Buffer{}
 	err := store.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("_users"))
+		b := tx.Bucket([]byte("__users"))
 		usr := b.Get([]byte(email))
 
 		_, err := val.Write(usr)
@@ -152,7 +152,7 @@ func User(email string) ([]byte, error) {
 func UserAll() ([][]byte, error) {
 	var users [][]byte
 	err := store.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("_users"))
+		b := tx.Bucket([]byte("__users"))
 		err := b.ForEach(func(k, v []byte) error {
 			users = append(users, v)
 			return nil
@@ -201,7 +201,7 @@ func SetRecoveryKey(email string) (string, error) {
 	key := fmt.Sprintf("%d", rand.Int63())
 
 	err := store.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte("_recoveryKeys"))
+		b, err := tx.CreateBucketIfNotExists([]byte("__recoveryKeys"))
 		if err != nil {
 			return err
 		}
@@ -226,7 +226,7 @@ func RecoveryKey(email string) (string, error) {
 	key := &bytes.Buffer{}
 
 	err := store.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("_recoveryKeys"))
+		b := tx.Bucket([]byte("__recoveryKeys"))
 		if b == nil {
 			return errors.New("No database found for checking keys.")
 		}

--- a/system/tls/enable.go
+++ b/system/tls/enable.go
@@ -42,7 +42,7 @@ func setup() {
 	if host == nil {
 		log.Fatalln("No 'domain' field set in Configuration. Please add a domain before attempting to make certificates.")
 	}
-	fmt.Println("Using", host, "as host/domain for certificate...")
+	fmt.Println("Using", string(host), "as host/domain for certificate...")
 	fmt.Println("NOTE: if the host/domain is not configured properly or is unreachable, HTTPS set-up will fail.")
 
 	email, err := db.Config("admin_email")
@@ -53,7 +53,7 @@ func setup() {
 	if email == nil {
 		log.Fatalln("No 'admin_email' field set in Configuration. Please add an admin email before attempting to make certificates.")
 	}
-	fmt.Println("Using", email, "as contact email for certificate...")
+	fmt.Println("Using", string(email), "as contact email for certificate...")
 
 	m = autocert.Manager{
 		Prompt:      autocert.AcceptTOS,


### PR DESCRIPTION
This PR addresses the need for admins to recover their accounts by verifying their email address in the event that they lost or forgot their account password. Upon account recovery request, Ponzu sends an email to the account on record with a unique and immediately generated key, which is used to verify their ownership of the account. 

This uses github.com/nilslice/email SMTP client to send emails. Beware of IP blacklisting -- try not to execute this feature on a residential IP address as it is likely already blacklisted and will fail. 

Also, pagination is now live in the admin UI for all content, public & pending alike. 
 