### PR TITLE
[core] API request metrics are now stored per day

### DIFF
--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -195,15 +195,13 @@ func ChartData() (map[string]interface{}, error) {
 			// delete the record in db if it belongs to a day already in metrics,
 			// otherwise append it to requests to be analyzed
 			d := time.Unix(r.Timestamp/1000, 0).Format("01/02")
-			for i := range dates {
-				if metrics[i].Date == d {
-					err := b.Delete(k)
-					if err != nil {
-						return err
-					}
-				} else {
-					requests = append(requests, r)
+			if m.Get([]byte(d)) != nil {
+				err := b.Delete(k)
+				if err != nil {
+					return err
 				}
+			} else {
+				requests = append(requests, r)
 			}
 
 			return nil

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -5,7 +5,6 @@ package analytics
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"runtime"
@@ -183,8 +182,6 @@ func ChartData() (map[string]interface{}, error) {
 				}
 			}
 
-			fmt.Println(metrics)
-
 			return nil
 		})
 		if err != nil {
@@ -199,15 +196,10 @@ func ChartData() (map[string]interface{}, error) {
 				return nil
 			}
 
-			// delete the record in db if it belongs to a day already in metrics,
-			// otherwise append it to requests to be analyzed
-			d := time.Unix(r.Timestamp/1000, 0).Format("01/02")
-			if m.Get([]byte(d)) != nil {
-				err := b.Delete(k)
-				if err != nil {
-					return err
-				}
-			} else {
+			// append request to requests for analysis if its timestamp is today
+			// or its day is not already in cache
+			d := time.Unix(r.Timestamp/1000, 0)
+			if !d.Before(today) || m.Get([]byte(d.Format("01/02"))) != nil {
 				requests = append(requests, r)
 			}
 

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -199,7 +199,7 @@ func ChartData() (map[string]interface{}, error) {
 			// append request to requests for analysis if its timestamp is today
 			// and its day is not already in cache
 			d := time.Unix(r.Timestamp/1000, 0)
-			if !d.Before(today) && m.Get([]byte(d.Format("01/02"))) != nil {
+			if !d.Before(today) && m.Get([]byte(d.Format("01/02"))) == nil {
 				requests = append(requests, r)
 			}
 

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -273,7 +273,7 @@ CHECK_REQUEST:
 	err = store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("__metrics"))
 
-		for i := range metrics {
+		for i := range dates {
 			if total[i] == 0 {
 				total[i] = metrics[i].Total
 			}
@@ -282,7 +282,7 @@ CHECK_REQUEST:
 				unique[i] = metrics[i].Unique
 			}
 
-			k := metrics[i].Date
+			k := dates[i]
 			if b.Get([]byte(k)) == nil {
 				v, err := json.Marshal(metrics[i])
 				if err != nil {

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -197,9 +197,9 @@ func ChartData() (map[string]interface{}, error) {
 			}
 
 			// append request to requests for analysis if its timestamp is today
-			// or its day is not already in cache
+			// and its day is not already in cache
 			d := time.Unix(r.Timestamp/1000, 0)
-			if !d.Before(today) || m.Get([]byte(d.Format("01/02"))) != nil {
+			if !d.Before(today) && m.Get([]byte(d.Format("01/02"))) != nil {
 				requests = append(requests, r)
 			}
 
@@ -281,15 +281,15 @@ CHECK_REQUEST:
 				unique[i] = metrics[i].Unique
 			}
 
-			k := dates[i]
-			if b.Get([]byte(k)) == nil {
+			k := []byte(dates[i])
+			if b.Get(k) == nil {
 				if metrics[i].Total != 0 {
 					v, err := json.Marshal(metrics[i])
 					if err != nil {
 						return err
 					}
 
-					err = b.Put([]byte(k), v)
+					err = b.Put(k, v)
 					if err != nil {
 						return err
 					}

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -192,11 +192,16 @@ func ChartData() (map[string]interface{}, error) {
 			}
 
 			// append request to requests for analysis if its timestamp is today
-			// or if its day is not already in cache
+			// or if its day is not already in cache, otherwise delete it
 			d := time.Unix(r.Timestamp/1000, 0)
 			_, inCache := currentMetrics[d.Format("01/02")]
 			if !d.Before(today) || !inCache {
 				requests = append(requests, r)
+			} else {
+				err := b.Delete(k)
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/system/api/analytics/init.go
+++ b/system/api/analytics/init.go
@@ -5,6 +5,7 @@ package analytics
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"runtime"
@@ -181,6 +182,8 @@ func ChartData() (map[string]interface{}, error) {
 					metrics[i] = metric
 				}
 			}
+
+			fmt.Println(metrics)
 
 			return nil
 		})


### PR DESCRIPTION
Rather than recalculating metrics for days prior to today (where data should never change) we now store these in a `__metrics` bucket. This reduces CPU on higher load systems. Though, there is still fairly high CPU usage at extremes. If there is interest or need, we can further optimize this or offer a way to toggle analytics completely.